### PR TITLE
Complete metadata support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v2
     - name: start pdns_server
       run: tests/start_server.sh
-    - name: run test playbook for pdns_auth_zone
-      run: /ansible/bin/ansible-playbook -M . -i localhost, tests/test-paz-playbook.yml
     - name: run test playbook for pdns_auth_tsigkey
       run: /ansible/bin/ansible-playbook -M . -i localhost, tests/test-patk-playbook.yml
+    - name: run test playbook for pdns_auth_zone
+      run: /ansible/bin/ansible-playbook -M . -i localhost, tests/test-paz-playbook.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to 0.0.15 version of API specification which documents all response objects.
 
+- Added support for metadata-in-zone properties.
+
 ## 1.0.0 - 2020-04-03
 
 First release!

--- a/tests/test-patk-playbook.yml
+++ b/tests/test-patk-playbook.yml
@@ -85,3 +85,14 @@
       failed_when:
         - result.failed == true
         - result.changed != true
+
+    - name: leave key for zone tests
+      pdns_auth_tsigkey:
+        <<: *common
+        name: axfr-key
+        state: present
+      register: result
+      failed_when:
+        - result.failed == true
+        - result.key.exists == false
+        - result.key.algoritm != 'hmac-md5'

--- a/tests/test-paz-playbook.yml
+++ b/tests/test-paz-playbook.yml
@@ -34,7 +34,8 @@
           nameservers:
             - 'ns.example.'
         metadata:
-          allow_axfr_from: ['AUTO-NS']
+          allow_axfr_from:
+            - 'AUTO-NS'
           ixfr: true
           axfr_source: '127.0.0.1'
       register: result
@@ -67,10 +68,14 @@
         properties:
           kind: 'Master'
         metadata:
-          allow_axfr_from: ['AUTO-NS', '::']
+          allow_axfr_from:
+            - 'AUTO-NS'
+            - '::'
           ixfr: false
           axfr_source: '127.0.0.8'
           slave_renotify: true
+          tsig_allow_axfr:
+            - 'axfr-key'
       register: result
       failed_when:
         - result.changed != true
@@ -79,6 +84,7 @@
         - result.zone.metadata.ixfr != false
         - result.zone.metadata.axfr_source != '127.0.0.8'
         - result.zone.metadata.slave_renotify != true
+        - result.zone.tsig_allow_axfr[0] != 'axfr-key'
 
     - name: check notify for zone
       pdns_auth_zone:
@@ -108,6 +114,9 @@
           masters:
             - '1.1.1.1'
             - '::1'
+        metadata:
+          axfr_master_tsig:
+            - 'axfr-key'
       register: result
       failed_when:
         - result.changed != true
@@ -115,6 +124,7 @@
         - result.zone.kind != 'Slave'
         - result.zone.masters[0] != '1.1.1.1'
         - result.zone.masters[1] != '::1'
+        - result.zone.axfr_master_tsig[0] != 'axfr-key'
 
     - name: check slave zone retrieval
       pdns_auth_zone:


### PR DESCRIPTION
This PR completes metadata support by mapping all of the 'zone properties' that are really metadata attributes into attributes in the pdns_auth_zone module.

It also exposes two metadata items which are immutable (PRESIGNED and LUA-AXFR-SCRIPT) so that Ansible users can inspect them.