### PR TITLE
Stop installing 'buildah' during Actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,14 +24,6 @@ jobs:
     steps:
     - name: checkout code
       uses: actions/checkout@v2
-    - name: install buildah
-      run: |
-        . /etc/os-release
-        sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${ID^}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-        wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${ID^}_${VERSION_ID}/Release.key -O Release.key
-        sudo apt-key add - < Release.key
-        sudo apt-get --quiet=2 update
-        sudo apt-get --quiet=2 --yes install buildah
     - name: build tox image
       run: tests/make_tox_container.sh
     - name: display image name
@@ -51,14 +43,6 @@ jobs:
     steps:
     - name: checkout code
       uses: actions/checkout@v2
-    - name: install buildah
-      run: |
-        . /etc/os-release
-        sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${ID^}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-        wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${ID^}_${VERSION_ID}/Release.key -O Release.key
-        sudo apt-key add - < Release.key
-        sudo apt-get --quiet=2 update
-        sudo apt-get --quiet=2 --yes install buildah
     - name: build pdns image
       run: tests/make_pdns_container.sh ${{ matrix.pdns }}
     - name: display image name


### PR DESCRIPTION
The base image now includes buildah, so there is no need to install
it.