### PR TITLE
Improve performance by eliminating rrsets from API zone responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Correct population of existing zone properties.
 - Handle API-RECTIFY as a binary zone property instead of ternary.
+- Improve performance by requesting that rrsets not be returned in zone API calls.
 
 ## [1.2.1] - 2020-08-15
 

--- a/api-swagger.json
+++ b/api-swagger.json
@@ -403,6 +403,13 @@
             "in": "path",
             "required": true,
             "description": "The id of the zone to retrieve"
+          },
+          {
+            "name": "rrsets",
+            "in": "query",
+            "description": "\u201ctrue\u201d (default) or \u201cfalse\u201d, whether to include the \u201crrsets\u201d in the response Zone object.",
+            "type": "boolean",
+            "default": true
           }
         ],
         "responses": {

--- a/pdns_auth_zone.py
+++ b/pdns_auth_zone.py
@@ -490,7 +490,7 @@ class APIZonesWrapper(object):
 
     @APIExceptionHandler
     def createZone(self, **kwargs):
-        return self.raw_api.createZone(server_id=self.server_id, **kwargs).result()
+        return self.raw_api.createZone(server_id=self.server_id, rrsets=False, **kwargs).result()
 
     @APIExceptionHandler
     def deleteZone(self):
@@ -501,7 +501,7 @@ class APIZonesWrapper(object):
     @APIExceptionHandler
     def listZone(self):
         return self.raw_api.listZone(
-            server_id=self.server_id, zone_id=self.zone_id
+            server_id=self.server_id, zone_id=self.zone_id, rrsets=False
         ).result()
 
     @APIExceptionHandler
@@ -1184,9 +1184,7 @@ def main():
             for setter in ZoneMetadata.setters(module.params["metadata"]):
                 setter(zone_struct)
 
-        partial_zone_info = api_client.zones.createZone(
-            rrsets=False, zone_struct=zone_struct
-        )
+        partial_zone_info = api_client.zones.createZone(zone_struct=zone_struct)
 
         result["changed"] = True
         api_client.setZoneID(partial_zone_info["id"])


### PR DESCRIPTION
This module does not make uses of rrsets (resource record sets) so
there is no need for the server API responses to include them.