### PR TITLE
Various non-functional cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         pdns: [4.2, 4.3, master]
-        python: [py35, py36, py37, py38]
+        python: [py36, py37, py38]
       fail-fast: false
     container:
       image: docker://quay.io/kpfleming/apaa-test-images:pdns-${{ matrix.pdns }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,6 @@ jobs:
     - name: checkout code
       uses: actions/checkout@v2
     - name: run lint tests
-      run: tox -elint --workdir /root/tox
+      run: tox -elint-action --workdir /root/tox
       env:
-        LINTLY_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+        LINTLY_API_KEY: ${{ secrets.LINTLY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Python 3.5 support has been removed.
+
 ## [1.2.2] - 2020-08-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://opensource.org"><img height="150" align="left" src="https://opensource.org/files/OSIApprovedCropped.png" alt="Open Source Initiative Approved License logo"></a>
 [![CI](https://github.com/kpfleming/ansible-pdns-auth-zone/workflows/CI/badge.svg)](https://github.com/kpfleming/ansible-pdns-auth-zone/workflows/CI/badge.svg?branch=develop)
 [![build-image](https://github.com/kpfleming/ansible-pdns-auth-zone/workflows/build-image/badge.svg)](https://github.com/kpfleming/ansible-pdns-auth-zone/workflows/build-image/badge.svg?branch=develop)
-[![Python](https://img.shields.io/badge/python-3.5+-blue.svg)](https://www.python.org/download/releases/3.5.0/)
+[![Python](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/download/releases/3.6.0/)
 
 Ansible modules which can be used to manage zones and other content in
 [PowerDNS Authoritative servers.](https://www.powerdns.com/auth.html)

--- a/pdns_auth_zone.py
+++ b/pdns_auth_zone.py
@@ -490,7 +490,9 @@ class APIZonesWrapper(object):
 
     @APIExceptionHandler
     def createZone(self, **kwargs):
-        return self.raw_api.createZone(server_id=self.server_id, rrsets=False, **kwargs).result()
+        return self.raw_api.createZone(
+            server_id=self.server_id, rrsets=False, **kwargs
+        ).result()
 
     @APIExceptionHandler
     def deleteZone(self):

--- a/tests/make_pdns_container.sh
+++ b/tests/make_pdns_container.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 if [ -z "${1}" ]; then
     echo "Must specify a PowerDNS Auth version (or 'master')."
@@ -36,7 +36,9 @@ buildcmd apt-get install --yes --quiet=2 pdns-server pdns-backend-sqlite3
 buildcmd apt-get purge --yes --quiet=2 pdns-backend-bind
 buildcmd sqlite3 /run/pdns.sqlite3 '.read /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql'
 
-buildcmd rm -rf /var/lib/apt/lists/*
+buildcmd apt-get autoremove --yes --purge
+buildcmd apt-get clean autoclean
+buildcmd rm -rf "/var/lib/apt/lists/*"
 buildcmd rm -rf /root/.cache
 
 if buildah images --quiet ${image}; then

--- a/tests/make_tox_container.sh
+++ b/tests/make_tox_container.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 root=$(dirname ${BASH_SOURCE[0]})
 pdns=${1}
+pydeps=(build-essential libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev)
 
 image=quay.io/kpfleming/apaa-test-images:tox
 
@@ -18,21 +19,26 @@ buildah config --workingdir /root ${c}
 buildcmd apt-get update
 buildcmd apt-get install --yes --quiet=2 git
 
-buildcmd apt-get install --yes --quiet=2 build-essential libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev
-for pyver in 3.5.9 3.6.11 3.7.8 3.8.4; do
+buildcmd apt-get install --yes --quiet=2 ${pydeps[@]}
+for pyver in 3.6.11 3.7.8 3.8.5; do
     wget -O - https://www.python.org/ftp/python/${pyver}/Python-${pyver}.tgz | buildcmd tar xzf -
     buildah config --workingdir /root/Python-${pyver} ${c}
-    buildcmd ./configure --enable-optimizations
-    buildcmd make altinstall
+    buildcmd ./configure --disable-shared
+    buildcmd make -j2 altinstall
     buildah config --workingdir /root ${c}
     buildcmd rm -rf /root/Python-${pyver}
 done
+
+buildcmd rm -rf "/usr/local/lib/python3.?m*"
 
 buildcmd pip3.8 install tox
 buildah copy ${c} tox.ini
 buildcmd tox -eALL --notest --workdir /root/tox
 
-buildcmd rm -rf /var/lib/apt/lists/*
+buildcmd apt-get remove --yes --purge ${pydeps[@]}
+buildcmd apt-get autoremove --yes --purge
+buildcmd apt-get clean autoclean
+buildcmd rm -rf "/var/lib/apt/lists/*"
 buildcmd rm -rf /root/.cache
 
 if buildah images --quiet ${image}; then

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=NONE
+envlist=lint
 skipsdist=True
 [ansible-base]
 deps=
@@ -9,20 +9,24 @@ deps=
 commands=
     ansible-playbook -M . -i localhost, tests/test-patk-playbook.yml
     ansible-playbook -M . -i localhost, tests/test-paz-playbook.yml
-[testenv:lint]
+[testenv:lint-action]
+ignore_errors=true
 whitelist_externals=bash
+passenv=GITHUB_* LINTLY_API_KEY
 deps=
     black
     flake8
     lintly
 commands=
-    bash -c 'flake8 --ignore=E501,E402,E231 | lintly --format=flake8'
-    bash -c 'black --check | lintly --format=black'
-[testenv:py35-ansible]
-deps =
-    {[ansible-base]deps}
-commands =
-    {[ansible-base]commands}
+    bash -c 'flake8 --ignore=E501,E402,E231 | lintly --format=flake8 --no-request-changes'
+    bash -c 'black --check . 2>&1 >/dev/null | lintly --format=black --no-request-changes'
+[testenv:lint]
+deps=
+    black
+    flake8
+commands=
+    flake8 --ignore=E501,E402,E231
+    black --check .
 [testenv:py36-ansible]
 deps =
     {[ansible-base]deps}


### PR DESCRIPTION
* Python 3.5 support removed.

* Updated name of token used by Lintly.

* Renamed 'lint' environment in tox.ini to lint-action and added manual 'lint' environment.

* Display commands in log when images are being built.

* Additional cleanup during image builds to reduce image sizes.

* Use 2 CPUs when building Python from source.

* Reduce size of Python builds and disable shared library.

* Ensure that environment variables for GitHub Actions are passed into lint-action tox environment.
