### PR TITLE
Add support for SOA/NS record creation during zone creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Support for creation of SOA and NS records during zone creation, eliminating
+requirement to set server configuration properties to synthesize the records.
+
 ## [1.4.0] - 2020-11-23
 
 ### Changed

--- a/tests/test-paz-api-http.yml
+++ b/tests/test-paz-api-http.yml
@@ -39,6 +39,42 @@
         msg: "success"
       failed_when: result.failed != true
 
+    - name: check for failure during zone creation without properties
+      pdns_auth_zone:
+        <<: *common
+        name: d2.example.
+        state: present
+      ignore_errors: true
+      register: result
+
+    - name: display result
+      debug:
+        var: "result"
+
+    - name: check result
+      debug:
+        msg: "success"
+      failed_when: result.failed != true
+
+    - name: check for failure during zone creation without soa
+      pdns_auth_zone:
+        <<: *common
+        name: d2.example.
+        state: present
+        properties:
+          kind: 'Native'
+      ignore_errors: true
+      register: result
+
+    - name: display result
+      debug:
+        var: "result"
+
+    - name: check result
+      debug:
+        msg: "success"
+      failed_when: result.failed != true
+
     - name: check 'Native' zone creation
       pdns_auth_zone:
         <<: *common
@@ -48,6 +84,9 @@
           kind: 'Native'
           nameservers:
             - 'ns.example.'
+          soa:
+            mname: 'localhost.'
+            rname: 'hostmaster.localhost.'
         metadata:
           allow_axfr_from:
             - 'AUTO-NS'
@@ -128,8 +167,6 @@
         <<: *common
         name: d2.example.
         state: present
-        properties:
-          kind: 'Master'
         metadata:
           allow_axfr_from:
             - 'AUTO-NS'

--- a/tests/test-paz-api-local.yml
+++ b/tests/test-paz-api-local.yml
@@ -40,6 +40,42 @@
         msg: "success"
       failed_when: result.failed != true
 
+    - name: check for failure during zone creation without properties
+      pdns_auth_zone:
+        <<: *common
+        name: d2.example.
+        state: present
+      ignore_errors: true
+      register: result
+
+    - name: display result
+      debug:
+        var: "result"
+
+    - name: check result
+      debug:
+        msg: "success"
+      failed_when: result.failed != true
+
+    - name: check for failure during zone creation without soa
+      pdns_auth_zone:
+        <<: *common
+        name: d2.example.
+        state: present
+        properties:
+          kind: 'Native'
+      ignore_errors: true
+      register: result
+
+    - name: display result
+      debug:
+        var: "result"
+
+    - name: check result
+      debug:
+        msg: "success"
+      failed_when: result.failed != true
+
     - name: check 'Native' zone creation
       pdns_auth_zone:
         <<: *common
@@ -49,6 +85,9 @@
           kind: 'Native'
           nameservers:
             - 'ns.example.'
+          soa:
+            mname: 'localhost.'
+            rname: 'hostmaster.localhost.'
         metadata:
           allow_axfr_from:
             - 'AUTO-NS'
@@ -129,8 +168,6 @@
         <<: *common
         name: d2.example.
         state: present
-        properties:
-          kind: 'Master'
         metadata:
           allow_axfr_from:
             - 'AUTO-NS'


### PR DESCRIPTION
In order to produce a valid zone, the SOA record must be
properly constructed, and NS records must be created to
provide delegations to the nameservers for the zone.

The new 'soa' section of the 'properties' parameter
allows the various SOA fields to be populated, and the
existing 'nameservers' parameter is used to create the
NS records.

The only required configuration changes are the 'mname'
and 'rname' parameters in the 'soa' section.