### PR TITLE
Adding rrset and cryptokey modules, tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ virtual environment on the managed node.
   * PowerDNS Authoritative Server:
     - kpfleming.powerdns_auth.tsigkey: manage TSIG keys
     - kpfleming.powerdns_auth.zone: manage zones
+    - kpfleming.powerdns_auth.rrset: manage rrsets
+    - kpfleming.powerdns_auth.cryptokey: manage cryptokeys
 
 ## Using this collection
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ virtual environment on the managed node.
   * PowerDNS Authoritative Server:
     - kpfleming.powerdns_auth.tsigkey: manage TSIG keys
     - kpfleming.powerdns_auth.zone: manage zones
-    - kpfleming.powerdns_auth.rrset: manage rrsets
-    - kpfleming.powerdns_auth.cryptokey: manage cryptokeys
+    - kpfleming.powerdns_auth.rrset: manage RRsets
+    - kpfleming.powerdns_auth.cryptokey: manage CryptoKeys
 
 ## Using this collection
 

--- a/src/README.md
+++ b/src/README.md
@@ -68,3 +68,137 @@ Examples:
     algorithm: hmac-sha256
     key: '+8fQxgYhf5PVGPKclKnk8ReujIfWXOw/aEzzPPhDi6AGagpg/r954FPZdzgFfUjnmjMSA1Yu7vo6DQHVoGnRkw=='
 ```
+
+## kpfleming.powerdns_auth.rrset
+
+This module can be used to create and remove rrsets. It can also manage records in any rrset.
+Two modes are available for records management, you can either use the traditional" way :
+```yaml
+- name: Creating a rrset of record type A
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    type: A
+    records:
+      - content: 192.168.0.1
+```
+or use the record options from the ones supported :
+```yaml
+- name: Creating a rrset of record type A
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    A:
+      - address: 192.168.0.1
+```
+
+The supported types are :
+A,AAAA,CAA,CNAME,DNSKEY,DS,HINFO,HTTPS,LOC,MX,NAPTR,NS,NSEC,NSEC3PARAM,PTR,RP,SPF,SOA,SRV,SSHFP,SVCB,TLSA,TXT
+
+Idempotency is only supported when the `keep` option is provided.
+
+Examples:
+```yaml
+- name: Deleting rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    type: A
+
+- name: Replacing records in rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    A:
+      - address: 192.168.1.1
+
+- name: Updating records in rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    keep: true
+    NS:
+      - host: ns1.example.
+
+- name: Deleting records in rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    state: absent
+    keep: true
+    NS:
+      - host: ns1.example.
+
+- name: Listing all rrsets in zone
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    state: exists
+```
+
+## kpfleming.powerdns_auth.cryptokey
+
+This module can create, delete, activate/deactivate, publish/unpublish a cryptokey in a zone of PowerDNS Authoritative server.
+
+Note that for keytype, by default if only one key is present it will be used as a csk regardless ofthe provided type. For the key to assume its role another key of the opposite type has to be present (zsk for ksk and vice-versa).
+
+Examples:
+```yaml
+- name: Generate key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: present
+    cryptokey:
+      keytype: csk
+      algorithm: ed25519
+      active: true
+
+- name: Import key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: present
+    cryptokey:
+      keytype: zsk
+      dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+      privatekey: 'Private-key-format: v1.2\n
+                   Algorithm: 15 (ED25519)\n
+                   PrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n'
+      active: true
+
+- name: Delete key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: absent
+    cryptokey_id: 1
+
+- name: Activating key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: present
+    cryptokey_id: 1
+    cryptokey:
+      active: true
+
+- name: Listing a specific key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: exists
+    cryptokey_id: 1
+
+- name: Listing all keys in the zone
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: exists
+```

--- a/src/README.md
+++ b/src/README.md
@@ -71,10 +71,10 @@ Examples:
 
 ## kpfleming.powerdns_auth.rrset
 
-This module can be used to create and remove rrsets. It can also manage records in any rrset.
-Two modes are available for records management, you can either use the traditional" way :
+This module can be used to create and remove RRsets. It can also manage resource records in any RRset.
+Two modes are available for RRs management, you can either use the "standard" way :
 ```yaml
-- name: Creating a rrset of record type A
+- name: Creating an RRset of RR type A
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -83,9 +83,9 @@ Two modes are available for records management, you can either use the tradition
     records:
       - content: 192.168.0.1
 ```
-or use the record options from the ones supported :
+or use the resource record options from one of the supported types :
 ```yaml
-- name: Creating a rrset of record type A
+- name: Creating an RRset of RR type A
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -101,14 +101,14 @@ Idempotency is only supported when the `keep` option is provided.
 
 Examples:
 ```yaml
-- name: Deleting rrset
+- name: Deleting an RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
     name: ns.zone.example.
     type: A
 
-- name: Replacing records in rrset
+- name: Replacing an RR in an RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -116,7 +116,7 @@ Examples:
     A:
       - address: 192.168.1.1
 
-- name: Updating records in rrset
+- name: Adding an RR to an RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -125,7 +125,7 @@ Examples:
     NS:
       - host: ns1.example.
 
-- name: Deleting records in rrset
+- name: Deleting an RR in an RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -135,7 +135,7 @@ Examples:
     NS:
       - host: ns1.example.
 
-- name: Listing all rrsets in zone
+- name: Listing all RRsets in a given zone
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -144,7 +144,7 @@ Examples:
 
 ## kpfleming.powerdns_auth.cryptokey
 
-This module can create, delete, activate/deactivate, publish/unpublish a cryptokey in a zone of PowerDNS Authoritative server.
+This module can create, delete, activate/deactivate, publish/unpublish a CryptoKey in a zone of PowerDNS Authoritative server.
 
 Note that for keytype, by default if only one key is present it will be used as a csk regardless ofthe provided type. For the key to assume its role another key of the opposite type has to be present (zsk for ksk and vice-versa).
 
@@ -155,23 +155,21 @@ Examples:
     api_key: foo
     zone_name: crypto.example.
     state: present
-    cryptokey:
-      keytype: csk
-      algorithm: ed25519
-      active: true
+    keytype: csk
+    algorithm: ed25519
+    active: true
 
 - name: Import key
   kpfleming.powerdns_auth.cryptokey:
     api_key: foo
     zone_name: crypto.example.
     state: present
-    cryptokey:
-      keytype: zsk
-      dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
-      privatekey: 'Private-key-format: v1.2\n
-                   Algorithm: 15 (ED25519)\n
-                   PrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n'
-      active: true
+    keytype: zsk
+    dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+    privatekey: 'Private-key-format: v1.2\n
+                 Algorithm: 15 (ED25519)\n
+                 PrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n'
+    active: true
 
 - name: Delete key
   kpfleming.powerdns_auth.cryptokey:
@@ -186,15 +184,14 @@ Examples:
     zone_name: crypto.example.
     state: present
     cryptokey_id: 1
-    cryptokey:
-      active: true
+    active: true
 
 - name: Listing a specific key
   kpfleming.powerdns_auth.cryptokey:
     api_key: foo
     zone_name: crypto.example.
     state: exists
-    cryptokey_id: 1
+    id: 1
 
 - name: Listing all keys in the zone
   kpfleming.powerdns_auth.cryptokey:

--- a/src/README.md
+++ b/src/README.md
@@ -95,7 +95,7 @@ or use the resource record options from one of the supported types :
 ```
 
 The supported types are :
-A,AAAA,CAA,CNAME,DNSKEY,DS,HINFO,HTTPS,LOC,MX,NAPTR,NS,NSEC,NSEC3PARAM,PTR,RP,SPF,SOA,SRV,SSHFP,SVCB,TLSA,TXT
+A,AAAA,CAA,CNAME,DNSKEY,DS,HINFO,HTTPS,LOC,MX,NAPTR,NS,PTR,RP,SPF,SOA,SRV,SSHFP,SVCB,TLSA,TXT
 
 Idempotency is only supported when the `keep` option is provided.
 

--- a/src/plugins/module_utils/api_wrapper.py
+++ b/src/plugins/module_utils/api_wrapper.py
@@ -171,3 +171,43 @@ class APITSIGKeyWrapper(APIWrapper):
     @api_exception_handler
     def putTSIGKey(self, **kwargs):  # noqa: N802
         return self.raw_api.putTSIGKey(server_id=self.server_id, **kwargs).result()
+
+
+class APICryptokeyWrapper(APIWrapper):
+    def __init__(self, *, module, result, object_type, zone_id, cryptokey_id):
+        super().__init__(module=module, result=result, object_type=object_type)
+        self.zone_id = zone_id
+        self.cryptokey_id = cryptokey_id
+
+    @api_exception_handler
+    def listCryptokeys(self):  # noqa: N802
+        return self.raw_api.listCryptokeys(
+            server_id=self.server_id,
+            zone_id=self.zone_id,
+        ).result()
+
+    @api_exception_handler
+    def createCryptokey(self, **kwargs):  # noqa: N802
+        return self.raw_api.createCryptokey(
+            server_id=self.server_id,
+            zone_id=self.zone_id,
+            **kwargs,
+        ).result()
+
+    @api_exception_handler
+    def getCryptokey(self):  # noqa: N802
+        return self.raw_api.getCryptokey(
+            server_id=self.server_id, zone_id=self.zone_id, cryptokey_id=self.cryptokey_id
+        ).result()
+
+    @api_exception_handler
+    def modifyCryptokey(self, **kwargs):  # noqa: N802
+        return self.raw_api.modifyCryptokey(
+            server_id=self.server_id, zone_id=self.zone_id, cryptokey_id=self.cryptokey_id, **kwargs
+        ).result()
+
+    @api_exception_handler
+    def deleteCryptokey(self):  # noqa: N802
+        return self.raw_api.deleteCryptokey(
+            server_id=self.server_id, zone_id=self.zone_id, cryptokey_id=self.cryptokey_id
+        ).result()

--- a/src/plugins/module_utils/api_wrapper.py
+++ b/src/plugins/module_utils/api_wrapper.py
@@ -60,8 +60,12 @@ def api_exception_handler(func):
         try:
             return func(self, *args, **kwargs)
         except self.api_exceptions_to_catch as e:
+            # The 404 error returns a simple string, not a dict hence the following line
+            err_msg = (
+                e.swagger_result if "error" not in e.swagger_result else e.swagger_result["error"]  # noqa: SIM401
+            )
             self.module.fail_json(
-                msg=f"API operation {func.__name__} returned '{e.swagger_result['error']}'",
+                msg=f"API operation {func.__name__} returned '{err_msg}'",
                 **self.result,
             )
 

--- a/src/plugins/modules/cryptokey.py
+++ b/src/plugins/modules/cryptokey.py
@@ -1,0 +1,472 @@
+#!/usr/bin/python
+# SPDX-FileCopyrightText: 2025 Mohamed Chamrouk <mohamed.chamrouk@proton.me>
+# SPDX-License-Identifier: Apache-2.0
+# -*- coding: utf-8 -*-
+
+import sys
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.kpfleming.powerdns_auth.plugins.module_utils.api_wrapper import (
+    APIWrapper,
+    api_exception_handler,
+)
+
+assert sys.version_info >= (3, 9), "This module requires Python 3.9 or newer."
+
+DOCUMENTATION = """
+%YAML 1.2
+---
+module: powerdns_auth_cryptokey
+
+short_description: Manages a cryptokey in a zone of PowerDNS Authoritative server
+
+description:
+  - This module can create, delete, activate/deactivate, publish/unpublish a cryptokey
+    in a zone of PowerDNS Authoritative server.
+
+requirements:
+  - bravado
+
+extends_documentation_fragment:
+  - kpfleming.powerdns_auth.api_details
+
+options:
+  state:
+    description:
+      - If V(present) the cryptokey will be created
+      - If V(present) and O(cryptokey_id) the cryptokey will be updated
+      - If V(absent) the cryptokey will be deleted
+      - If V(exists) lists all the keys in the zone
+      - If V(exists) and O(cryptokey_id) returns the corresponding cryptokey
+    choices: [ 'present', 'absent', 'exists' ]
+    type: str
+    required: false
+    default: 'present'
+  zone_name:
+    description:
+      - Name of the zone
+    type: str
+    required: true
+  server_id:
+    description:
+      - ID of the server managed.
+    type: str
+    default: localhost
+  api_url:
+    description:
+      - URL of the API of the PowerDNS Authoritative server.
+    type: str
+    default: 'http://localhost:8081'
+  api_spec_path:
+    description:
+      - API endpoint of the swagger resource.
+    type: str
+    default: /api/docs
+  api_key:
+    description:
+      - Key of the PowerDNS API.
+    type: str
+    required: true
+  cryptokey_id:
+    description:
+      - The cryptokey id.
+    type: str
+  cryptokey:
+    description:
+      - Cryptokey object definition.
+    type: dict
+    suboptions:
+      keytype:
+        description:
+          - The type of key, either zone signing key (zsk), key signing key (ksk)
+            or combined signing key (csk)
+          - Note that by default if only one key is present it will be used as a csk regardless of
+            the provided type. For the key to assume its role another key of the opposite type has
+            to be present (zsk for ksk and vice-versa).
+        type: str
+        choices: [ 'zsk', 'ksk', 'csk']
+        required: true
+      active:
+        description:
+          - Whether the key is active or not.
+        type: bool
+        default: false
+      published:
+        description:
+          - Whether the key is published or not.
+        type: bool
+        default: true
+      dnskey:
+        description:
+          - The DNSKEY record for the cryptokey.
+          - Required alongside O(privatekey) for cryptokey creation if O(algorithm)
+            is not present.
+        type: str
+      privatekey:
+        description:
+          - The privatekey in ISC format.
+          - Required if O(dnskey)
+        type: str
+      algorithm:
+        description:
+          - Algorithm for key generation.
+        type: str
+      bits:
+        description:
+          - Size of the key in bits when O(algorithm) is a variant of RSA.
+        type: int
+        default: 4096
+
+author:
+  - Mohamed Chamrouk (@mohamed-chamrouk)
+"""
+
+EXAMPLES = """
+%YAML 1.2
+---
+- name: Generate key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: present
+    cryptokey:
+      keytype: csk
+      algorithm: ed25519
+      active: true
+
+- name: Import key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: present
+    cryptokey:
+      keytype: zsk
+      dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+      privatekey: |
+        Private-key-format: v1.2
+        Algorithm: 15 (ED25519)
+        PrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=
+      active: true
+
+- name: Delete key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: absent
+    cryptokey_id: 1
+
+- name: Activating key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: present
+    cryptokey_id: 1
+    cryptokey:
+      active: true
+
+- name: Listing a specific key
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: exists
+    cryptokey_id: 1
+
+- name: Listing all keys in the zone
+  kpfleming.powerdns_auth.cryptokey:
+    api_key: foo
+    zone_name: crypto.example.
+    state: exists
+"""
+
+RETURN = """
+%YAML 1.2
+---
+exists:
+  description:
+    - If cryptokey_id is provided, whether a corresponding key exists
+    - Otherwise if there is any key in the zone
+  returned: when state is exists
+  type: bool
+cryptokey:
+  description:
+    - The corresponding key when state is exists and cryptokey_id is provided
+  returned: when state is exists and cryptokey_id is provided
+  type: dict
+  contains:
+    active:
+      description: whether or not the key is active
+      type: bool
+    algorithm:
+      description: the key algorithm
+      type: str
+    bits:
+      description: size in bits, used in dnskey record
+      type: int
+    dnskey:
+      description: the dnskey record
+      type: str
+    ds:
+      description: when key is ksk or csk, used to create the DS record on the parent zone
+      type: list
+      elements: str
+    flags:
+      description: flags
+      type: str
+    id:
+      description: the id of the key
+      type: str
+    keytype:
+      description: the type of the key
+      type: str
+    published:
+      description: whether or not the key is published
+      type: bool
+    type:
+      description: always Cryptokey
+      type: str
+cryptokeys:
+  description:
+    - List of existing cryptokeys after all the changes are made.
+  returned: always except when cryptokey is returned
+  type: list
+  elements: dict
+  contains:
+    active:
+      description: whether or not the key is active
+      type: bool
+    algorithm:
+      description: the key algorithm
+      type: str
+    bits:
+      description: size in bits, used in dnskey record
+      type: int
+    dnskey:
+      description: the dnskey record
+      type: str
+    ds:
+      description: when key is ksk or csk, used to create the DS record on the parent zone
+      type: list
+      elements: str
+    flags:
+      description: flags
+      type: str
+    id:
+      description: the id of the key
+      type: str
+    keytype:
+      description: the type of the key
+      type: str
+    published:
+      description: whether or not the key is published
+      type: bool
+    type:
+      description: always Cryptokey
+      type: str
+"""
+
+
+class APIZoneWrapper(APIWrapper):
+    def __init__(self, *, module, result, object_type, zone_id):
+        super().__init__(module=module, result=result, object_type=object_type)
+        self.zone_id = zone_id
+
+    @api_exception_handler
+    def listZones(self, **kwargs):  # noqa: N802
+        return self.raw_api.listZones(server_id=self.server_id, **kwargs).result()
+
+
+class APICryptokeyWrapper(APIWrapper):
+    def __init__(self, *, module, result, object_type, zone_id, cryptokey_id):
+        super().__init__(module=module, result=result, object_type=object_type)
+        self.zone_id = zone_id
+        self.cryptokey_id = cryptokey_id
+
+    @api_exception_handler
+    def listCryptokeys(self):  # noqa: N802
+        return self.raw_api.listCryptokeys(
+            server_id=self.server_id,
+            zone_id=self.zone_id,
+        ).result()
+
+    @api_exception_handler
+    def createCryptokey(self, **kwargs):  # noqa: N802
+        return self.raw_api.createCryptokey(
+            server_id=self.server_id,
+            zone_id=self.zone_id,
+            **kwargs,
+        ).result()
+
+    @api_exception_handler
+    def getCryptokey(self):  # noqa: N802
+        return self.raw_api.getCryptokey(
+            server_id=self.server_id, zone_id=self.zone_id, cryptokey_id=self.cryptokey_id
+        ).result()
+
+    @api_exception_handler
+    def modifyCryptokey(self, **kwargs):  # noqa: N802
+        return self.raw_api.modifyCryptokey(
+            server_id=self.server_id, zone_id=self.zone_id, cryptokey_id=self.cryptokey_id, **kwargs
+        ).result()
+
+    @api_exception_handler
+    def deleteCryptokey(self):  # noqa: N802
+        return self.raw_api.deleteCryptokey(
+            server_id=self.server_id, zone_id=self.zone_id, cryptokey_id=self.cryptokey_id
+        ).result()
+
+
+def main():
+    module_args = {
+        "state": {
+            "type": "str",
+            "default": "present",
+            "choices": ["present", "absent", "exists"],
+        },
+        "zone_name": {
+            "type": "str",
+            "required": True,
+        },
+        "server_id": {
+            "type": "str",
+            "default": "localhost",
+        },
+        "api_url": {
+            "type": "str",
+            "default": "http://localhost:8081",
+        },
+        "api_spec_path": {
+            "type": "str",
+            "default": "/api/docs",
+        },
+        "api_key": {
+            "type": "str",
+            "required": True,
+            "no_log": True,
+        },
+        "cryptokey_id": {
+            "type": "str",
+        },
+        "cryptokey": {
+            "type": "dict",
+            "options": {
+                "keytype": {"type": "str", "required": False, "choices": ["zsk", "ksk", "csk"]},
+                "active": {"type": "bool", "default": False},
+                "published": {"type": "bool", "default": True},
+                "dnskey": {"type": "str", "required": False},
+                "privatekey": {"type": "str", "required": False},
+                "algorithm": {"type": "str", "required": False},
+                "bits": {"type": "int", "default": 4096},
+            },
+        },
+    }
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=(("state", "present", ["cryptokey"]), ("state", "absent", ["cryptokey_id"])),
+    )
+
+    result = {"changed": False, "cryptokey": {}, "cryptokeys": []}
+
+    params = module.params
+    state = params["state"]
+    zone_name = params["zone_name"]
+
+    api_zone_client = APIZoneWrapper(
+        module=module, result=result, object_type="zones", zone_id=None
+    )
+
+    api_cryptokey_client = APICryptokeyWrapper(
+        module=module, result=result, object_type="zonecryptokey", zone_id=None, cryptokey_id=None
+    )
+
+    partial_zone_info = api_zone_client.listZones(zone=zone_name)
+
+    if len(partial_zone_info) == 0:
+        module.fail_json(msg=f"No zone found for name {zone_name}", **result)
+
+    # get the zone_id from the zone_name
+    zone_id = partial_zone_info[0]["id"]
+    api_cryptokey_client.zone_id = zone_id
+
+    existing_zone_keys = api_cryptokey_client.listCryptokeys()
+
+    if state == "exists":
+        result["exists"] = False
+        if params["cryptokey_id"] is not None:
+            api_cryptokey_client.cryptokey_id = params["cryptokey_id"]
+            result["cryptokey"] = api_cryptokey_client.getCryptokey()
+            # nonexistent key id is handled by the API error handler
+        else:
+            result["cryptokeys"] = existing_zone_keys
+
+        if result["cryptokey"] or result["cryptokeys"]:
+            result["exists"] = True
+    elif state == "present":
+        cryptokey_def = params["cryptokey"]
+        if params["cryptokey_id"] is None:
+            # Creating the cryptokey
+            if cryptokey_def["keytype"] is None:
+                module.fail_json(msg="Missing keytype option in cryptokey definition", **result)
+
+            generated_key_fields = ["algorithm"]
+            imported_key_fields = ["dnskey", "privatekey"]
+            common_fields = ["keytype", "active", "published"]
+
+            if cryptokey_def["algorithm"] is not None:
+                if "rsa" in cryptokey_def["algorithm"].lower():
+                    # RSA type algorithm requires the bits field
+                    generated_key_fields += ["bits"]
+                result_fields = common_fields + generated_key_fields
+            elif cryptokey_def["privatekey"] is not None and cryptokey_def["dnskey"] is not None:
+                result_fields = common_fields + imported_key_fields
+            else:
+                module.fail_json(msg="Wrong options provided for cryptokey creation", **result)
+
+            cryptokey = {field: cryptokey_def[field] for field in result_fields}
+
+            api_cryptokey_client.createCryptokey(cryptokey=cryptokey)
+        else:
+            # Updating the cryptokey
+            cryptokeys_ids = [str(key["id"]) for key in existing_zone_keys]
+
+            if params["cryptokey_id"] in cryptokeys_ids:
+                cryptokey = {
+                    "active": cryptokey_def["active"],
+                    "published": cryptokey_def["published"],
+                }
+            else:
+                module.fail_json(
+                    msg=f"Key of id {params['cryptokey_id']} not found \
+                          for zone {params['zone_name']}",
+                    **result,
+                )
+
+            api_cryptokey_client.cryptokey_id = params["cryptokey_id"]
+            api_cryptokey_client.modifyCryptokey(cryptokey=cryptokey)
+
+        result["changed"] = True
+    else:
+        # when state is absent
+        cryptokeys_ids = [str(key["id"]) for key in existing_zone_keys]
+        cryptokey_id = params["cryptokey_id"]
+
+        if cryptokey_id in cryptokeys_ids:
+            api_cryptokey_client.cryptokey_id = cryptokey_id
+            api_cryptokey_client.deleteCryptokey()
+        else:
+            module.fail_json(
+                msg=f"Key of id {params['cryptokey_id']} not found for zone {params['zone_name']}",
+                **result,
+            )
+
+        result["changed"] = True
+
+    if result["changed"]:
+        result["cryptokeys"] = api_cryptokey_client.listCryptokeys()
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/plugins/modules/cryptokey.py
+++ b/src/plugins/modules/cryptokey.py
@@ -10,7 +10,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.api_module_args import API_MODULE_ARGS
 from ..module_utils.api_wrapper import APICryptokeyWrapper, APIZoneWrapper
 
-assert sys.version_info >= (3, 9), "This module requires Python 3.9 or newer."
+assert sys.version_info >= (3, 10), "This module requires Python 3.9 or newer."
 
 DOCUMENTATION = """
 %YAML 1.2

--- a/src/plugins/modules/rrset.py
+++ b/src/plugins/modules/rrset.py
@@ -18,10 +18,10 @@ DOCUMENTATION = """
 ---
 module: powerdns_auth_rrset
 
-short_description: Manages a rrset in a zone of PowerDNS Authoritative server
+short_description: Manages an RRset in a zone of PowerDNS Authoritative server
 
 description:
-  - This module can create, delete or update a rrset inside a zone of
+  - This module can create, delete or update an RRset inside a zone of
     PowerDNS Authoritative server.
 
 requirements:
@@ -33,47 +33,27 @@ extends_documentation_fragment:
 options:
   state:
     description:
-      - If V(present) the rrset will be created unless it already exists
+      - If V(present) the RRset will be created unless it already exists
         in which case if O(keep=false) records will be replaces and if
-        O(keep=true) new records will be added.
-      - If V(absent) and O(keep=false) the whole rrset will be deleted
-      - If V(absent) and O(keep=true) only the matching records will be
+        O(keep=true) new RRs will be added.
+      - If V(absent) and O(keep=false) the whole RRset will be deleted
+      - If V(absent) and O(keep=true) only the matching RRs will be
         deleted
-      - If V(exists) a list of all rrsets in the zone will be returned
+      - If V(exists) a list of all RRsets in the zone will be returned
       - If V(exists) and O(name) and/or O(type) existence will be checked
-        and matching rrsets will be returned
+        and matching RRsets will be returned
     choices: [ 'present', 'absent', 'exists' ]
     type: str
     required: false
     default: 'present'
   name:
     description:
-      - Name of the rrset
+      - Name of the RRset
       - Required if O(state=present) or O(state=absent)
     type: str
   zone_name:
     description:
       - Name of the zone
-    type: str
-    required: true
-  server_id:
-    description:
-      - ID of the server managed.
-    type: str
-    default: localhost
-  api_url:
-    description:
-      - URL of the API of the PowerDNS Authoritative server.
-    type: str
-    default: 'http://localhost:8081'
-  api_spec_path:
-    description:
-      - API endpoint of the swagger ressource.
-    type: str
-    default: /api/docs
-  api_key:
-    description:
-      - Key of the PowerDNS API.
     type: str
     required: true
   keep:
@@ -89,7 +69,7 @@ options:
   type:
     description:
       - Type of resource record (e.g. A, PTR, NSEC...).
-      - Required if O(state=absent) or O(state=present) and none of the record types options are
+      - Required if O(state=absent) or O(state=present) and none of the RR types options are
         provided.
     type: str
   records:
@@ -101,19 +81,19 @@ options:
     suboptions:
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
       content:
         description:
-          - The content of resource record.
+          - The content of the RR.
         type: str
         required: true
   A:
     description:
-      - Record of type A.
+      - RR of type A.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option is not present.
     type: list
     elements: dict
     suboptions:
@@ -124,14 +104,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   AAAA:
     description:
-      - Record of type AAAA.
+      - RR of type AAAA.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option is not present.
     type: list
     elements: dict
     suboptions:
@@ -142,14 +122,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   CAA:
     description:
-      - Certificate Authority Authorization record.
+      - Certificate Authority Authorization RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -172,14 +152,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   CNAME:
     description:
-      - Canonical name record.
+      - Canonical name RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -190,14 +170,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   DNSKEY:
     description:
-      - DNS Key record for DNSSEC.
+      - DNS Key RR for DNSSEC.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -225,14 +205,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   DS:
     description:
-      - Delegation Signer record for DNSSEC.
+      - Delegation Signer RR for DNSSEC.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -259,14 +239,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   HINFO:
     description:
-      - Host information record.
+      - Host information RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -282,14 +262,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   HTTPS:
     description:
-      - HTTPS service binding record.
+      - HTTPS service binding RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -309,14 +289,14 @@ options:
         type: str
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   LOC:
     description:
-      - Location record.
+      - Location RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -352,14 +332,14 @@ options:
         default: "10.0m"
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   MX:
     description:
-      - Mail exchange record.
+      - Mail exchange RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -375,14 +355,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   NAPTR:
     description:
-      - Name Authority Pointer record.
+      - Name Authority Pointer RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -418,14 +398,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   NS:
     description:
-      - Name server record.
+      - Name server RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -436,14 +416,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   NSEC:
     description:
-      - Next Secure record for DNSSEC.
+      - Next Secure RR for DNSSEC.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -459,14 +439,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   NSEC3PARAM:
     description:
-      - NSEC3 parameters record for DNSSEC.
+      - NSEC3 parameters RR for DNSSEC.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -494,14 +474,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   PTR:
     description:
-      - Pointer record for reverse DNS lookup.
+      - Pointer RR for reverse DNS lookup.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -512,14 +492,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   RP:
     description:
-      - Responsible person record.
+      - Responsible person RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -535,14 +515,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   SPF:
     description:
-      - Sender Policy Framework record.
+      - Sender Policy Framework RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -553,14 +533,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   SOA:
     description:
-      - Start of Authority record.
+      - Start of Authority RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -596,14 +576,14 @@ options:
         type: int
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   SRV:
     description:
-      - Service record.
+      - Service RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -629,14 +609,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   SSHFP:
     description:
-      - SSH fingerprint record.
+      - SSH fingerprint RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -659,14 +639,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   SVCB:
     description:
-      - Service binding record.
+      - Service binding RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -686,14 +666,14 @@ options:
         type: str
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   TLSA:
     description:
-      - Transport Layer Security Authentication record.
+      - Transport Layer Security Authentication RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -722,14 +702,14 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
   TXT:
     description:
-      - Text record.
+      - Text RR.
       - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other record type option not present.
+        and any of the other RR type option not present.
     type: list
     elements: dict
     suboptions:
@@ -740,7 +720,7 @@ options:
         required: true
       disabled:
         description:
-          - Whether or not this record is disabled.
+          - Whether or not this RR is disabled.
         type: bool
         default: false
 
@@ -751,7 +731,7 @@ author: Mohamed Chamrouk (@mohamed-chamrouk)
 EXAMPLES = """
 %YAML 1.2
 ---
-- name: Creating a rrset of record type A
+- name: Creating an RRset of RR type A
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -760,7 +740,7 @@ EXAMPLES = """
     records:
       - content: 192.168.0.1
 
-- name: Creating a rrset of record type A
+- name: Creating an RRset of RR type A
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -768,14 +748,14 @@ EXAMPLES = """
     A:
       - address: 192.168.0.1
 
-- name: Deleting rrset
+- name: Deleting an RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
     name: ns.zone.example.
     type: A
 
-- name: Replacing records in rrset
+- name: Replacing RR in an RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -783,7 +763,7 @@ EXAMPLES = """
     A:
       - address: 192.168.1.1
 
-- name: Updating records in rrset
+- name: Adding RR to an RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -792,7 +772,7 @@ EXAMPLES = """
     NS:
       - host: ns1.example.
 
-- name: Deleting records in rrset
+- name: Deleting RR in RRset
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -802,7 +782,7 @@ EXAMPLES = """
     NS:
       - host: ns1.example.
 
-- name: Listing all rrsets in zone
+- name: Listing all RRsets in a zone
   kpfleming.powerdns_auth.rrset:
     api_key: foo
     zone_name: zone.example.
@@ -813,68 +793,41 @@ RETURN = """
 %YAML 1.2
 ---
 name:
-  description: name of the rrset
+  description: name of the RRset
   returned: always
   type: str
   sample: rrset.example.
 exists:
-  description: whether the provided name and type lead to existing rrset(s)
+  description: whether the provided name and type lead to existing RRset(s)
   returned: when state is exists and name and/or type provided
   type: bool
-rrset:
-  description: single rrset resource
-  returned: when state is exists and name and type are provided
-  type: dict
-  contains:
-    comments:
-      description:
-        - list of comments on the rrset
-      type: list
-      elements: str
-    name:
-      description:
-        - name of the rrset
-      type: str
-    records:
-      description:
-        - list of the records
-      type: list
-      elements: str
-    ttl:
-      description:
-        - TTL of the records, in seconds.
-      type: int
-    type:
-      description:
-        - type of the record
-      type: str
 rrsets:
-  description: list of existing rrsets or rrsets after changes are made
-  returned: always except when rrset conditions are fulfilled
+  description: list of existing RRsets or RRsets after changes are made
+  returned: always
   type: list
   elements: dict
   contains:
     comments:
       description:
-        - list of comments on the rrset
+        - list of comments on the RRset
       type: list
       elements: str
     name:
       description:
-        - name of the rrset
+        - name of the RRset
       type: str
     records:
       description:
-        - list of the records
+        - RRs list
       type: list
       elements: str
     ttl:
       description:
-        - TTL of the records, in seconds.
+        - TTL of the RRs, in seconds.
       type: int
     type:
       description:
-        - type of the record
+        - RR type
       type: str
 """
 
@@ -908,7 +861,7 @@ class APIZoneRRSetWrapper(APIWrapper):
 def get_result_rrsets(rrsets, rrset_name, rrset_type):
     """
     Function to build the return object to the ansible module.
-    rrsets refers to the existings rrsets.
+    rrsets refers to the existings RRsets.
     rrset_name and rrset_type can be None, if provided it will filter rrsets based on those.
     """
     r = {
@@ -919,13 +872,13 @@ def get_result_rrsets(rrsets, rrset_name, rrset_type):
         if rrset_type is not None:
             r = {
                 "exists": False,
-                "rrset": {},
+                "rrsets": [],
             }
             for rrset in rrsets:
                 if rrset["name"] == rrset_name and rrset["type"] == rrset_type:
                     r = {
                         "exists": True,
-                        "rrset": rrset,
+                        "rrsets": [rrset],
                     }
         else:
             r = {
@@ -1341,7 +1294,7 @@ def main():
     # Check couldn't fit in AnsibleModule args
     type_classic = "type" in params and "records" in params
     if params["state"] == "present" and not (type_classic or rrset_record_types):
-        module.fail_json("State is present but no valid record has been provided")
+        module.fail_json("State is present but no valid RR has been provided")
 
     if rrset_record_types:
         rrset_records = [
@@ -1411,13 +1364,13 @@ def main():
                 if rrset["type"] is not None:
                     zone_struct.setdefault("rrsets", []).append(rrset)
                 else:
-                    module.fail_json("No valid record found for rrset creation.")
+                    module.fail_json("No valid record found for RRset creation.")
             elif rrset_changetype == "DELETE":
                 if existing_rrset:
                     zone_struct.setdefault("rrsets", []).append(rrset)
                 else:
                     module.fail_json(
-                        f"No matching rrset found for name: {rrset['name']} \
+                        f"No matching RRset found for name: {rrset['name']} \
                           and type: {rrset['type']}"
                     )
         elif rrset["records"] == existing_rrset["records"]:

--- a/src/plugins/modules/rrset.py
+++ b/src/plugins/modules/rrset.py
@@ -10,7 +10,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.api_module_args import API_MODULE_ARGS
 from ..module_utils.api_wrapper import APIZoneWrapper
 
-assert sys.version_info >= (3, 9), "This module requires Python 3.9 or newer."
+assert sys.version_info >= (3, 10), "This module requires Python 3.9 or newer."
 
 DOCUMENTATION = """
 %YAML 1.2
@@ -33,7 +33,7 @@ options:
   state:
     description:
       - If V(present) the RRset will be created unless it already exists
-        in which case if O(keep=false) records will be replaces and if
+        in which case if O(keep=false) RRs will be replaced and if
         O(keep=true) new RRs will be added.
       - If V(absent) and O(keep=false) the whole RRset will be deleted
       - If V(absent) and O(keep=true) only the matching RRs will be
@@ -67,13 +67,13 @@ options:
     default: 3600
   type:
     description:
-      - Type of resource record (e.g. A, PTR, NSEC...).
-      - Required if O(state=absent) or O(state=present) and none of the RR types options are
+      - Type of resource record (e.g. A, PTR...).
+      - Required if O(state=absent) or O(state=present) and none of the RR type options are
         provided.
     type: str
   records:
     description:
-      - Represents a list of records.
+      - Represents a list of RRs.
       - Required if O(type) and O(state=present).
     type: list
     elements: dict
@@ -91,8 +91,8 @@ options:
   A:
     description:
       - RR of type A.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option is not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -109,8 +109,8 @@ options:
   AAAA:
     description:
       - RR of type AAAA.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option is not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -127,8 +127,8 @@ options:
   CAA:
     description:
       - Certificate Authority Authorization RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -157,8 +157,8 @@ options:
   CNAME:
     description:
       - Canonical name RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -175,8 +175,8 @@ options:
   DNSKEY:
     description:
       - DNS Key RR for DNSSEC.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -210,8 +210,8 @@ options:
   DS:
     description:
       - Delegation Signer RR for DNSSEC.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -244,8 +244,8 @@ options:
   HINFO:
     description:
       - Host information RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -267,8 +267,8 @@ options:
   HTTPS:
     description:
       - HTTPS service binding RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -294,8 +294,8 @@ options:
   LOC:
     description:
       - Location RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -337,8 +337,8 @@ options:
   MX:
     description:
       - Mail exchange RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -360,8 +360,8 @@ options:
   NAPTR:
     description:
       - Name Authority Pointer RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -403,8 +403,8 @@ options:
   NS:
     description:
       - Name server RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -418,69 +418,11 @@ options:
           - Whether or not this RR is disabled.
         type: bool
         default: false
-  NSEC:
-    description:
-      - Next Secure RR for DNSSEC.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
-    type: list
-    elements: dict
-    suboptions:
-      next_domain:
-        description:
-          - Next domain name in canonical order.
-        type: str
-        required: true
-      type_bitmap:
-        description:
-          - Bitmap of record types present.
-        type: str
-        required: true
-      disabled:
-        description:
-          - Whether or not this RR is disabled.
-        type: bool
-        default: false
-  NSEC3PARAM:
-    description:
-      - NSEC3 parameters RR for DNSSEC.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
-    type: list
-    elements: dict
-    suboptions:
-      hash_algorithm:
-        description:
-          - Hash algorithm used.
-        type: int
-        required: true
-        choices: [1]
-      flags:
-        description:
-          - Flags field.
-        type: int
-        required: true
-        choices: [0, 1]
-      iterations:
-        description:
-          - Number of hash iterations.
-        type: int
-        required: true
-      salt:
-        description:
-          - Salt value for hashing.
-        type: str
-        required: true
-      disabled:
-        description:
-          - Whether or not this RR is disabled.
-        type: bool
-        default: false
   PTR:
     description:
       - Pointer RR for reverse DNS lookup.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -497,8 +439,8 @@ options:
   RP:
     description:
       - Responsible person RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -520,8 +462,8 @@ options:
   SPF:
     description:
       - Sender Policy Framework RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -538,8 +480,8 @@ options:
   SOA:
     description:
       - Start of Authority RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -581,8 +523,8 @@ options:
   SRV:
     description:
       - Service RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -614,8 +556,8 @@ options:
   SSHFP:
     description:
       - SSH fingerprint RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -644,8 +586,8 @@ options:
   SVCB:
     description:
       - Service binding RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -671,8 +613,8 @@ options:
   TLSA:
     description:
       - Transport Layer Security Authentication RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -707,8 +649,8 @@ options:
   TXT:
     description:
       - Text RR.
-      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
-        and any of the other RR type option not present.
+      - At least one RR type is required if O(state=present) or O(state=absent) and O(type)
+        is not present.
     type: list
     elements: dict
     suboptions:
@@ -1058,26 +1000,6 @@ def main():
                 "disabled": {"type": "bool", "required": False, "default": False},
             },
         },
-        "NSEC": {
-            "type": "list",
-            "elements": "dict",
-            "options": {
-                "next_domain": {"type": "str", "required": True},
-                "type_bitmap": {"type": "str", "required": True},
-                "disabled": {"type": "bool", "required": False, "default": False},
-            },
-        },
-        "NSEC3PARAM": {
-            "type": "list",
-            "elements": "dict",
-            "options": {
-                "hash_algorithm": {"type": "int", "required": True, "choices": [1]},
-                "flags": {"type": "int", "required": True, "choices": [0, 1]},
-                "iterations": {"type": "int", "required": True},
-                "salt": {"type": "str", "required": True},
-                "disabled": {"type": "bool", "required": False, "default": False},
-            },
-        },
         "PTR": {
             "type": "list",
             "elements": "dict",
@@ -1182,8 +1104,6 @@ def main():
         "MX",
         "NAPTR",
         "NS",
-        "NSEC",
-        "NSEC3PARAM",
         "PTR",
         "RP",
         "SPF",

--- a/src/plugins/modules/rrset.py
+++ b/src/plugins/modules/rrset.py
@@ -1,0 +1,1473 @@
+#!/usr/bin/python
+# SPDX-FileCopyrightText: 2025 Mohamed Chamrouk <mohamed.chamrouk@proton.me>
+# SPDX-License-Identifier: Apache-2.0
+# -*- coding: utf-8 -*-
+
+import sys
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.kpfleming.powerdns_auth.plugins.module_utils.api_wrapper import (
+    APIWrapper,
+    api_exception_handler,
+)
+
+assert sys.version_info >= (3, 9), "This module requires Python 3.9 or newer."
+
+DOCUMENTATION = """
+%YAML 1.2
+---
+module: powerdns_auth_rrset
+
+short_description: Manages a rrset in a zone of PowerDNS Authoritative server
+
+description:
+  - This module can create, delete or update a rrset inside a zone of
+    PowerDNS Authoritative server.
+
+requirements:
+  - bravado
+
+extends_documentation_fragment:
+  - kpfleming.powerdns_auth.api_details
+
+options:
+  state:
+    description:
+      - If V(present) the rrset will be created unless it already exists
+        in which case if O(keep=false) records will be replaces and if
+        O(keep=true) new records will be added.
+      - If V(absent) and O(keep=false) the whole rrset will be deleted
+      - If V(absent) and O(keep=true) only the matching records will be
+        deleted
+      - If V(exists) a list of all rrsets in the zone will be returned
+      - If V(exists) and O(name) and/or O(type) existence will be checked
+        and matching rrsets will be returned
+    choices: [ 'present', 'absent', 'exists' ]
+    type: str
+    required: false
+    default: 'present'
+  name:
+    description:
+      - Name of the rrset
+      - Required if O(state=present) or O(state=absent)
+    type: str
+  zone_name:
+    description:
+      - Name of the zone
+    type: str
+    required: true
+  server_id:
+    description:
+      - ID of the server managed.
+    type: str
+    default: localhost
+  api_url:
+    description:
+      - URL of the API of the PowerDNS Authoritative server.
+    type: str
+    default: 'http://localhost:8081'
+  api_spec_path:
+    description:
+      - API endpoint of the swagger ressource.
+    type: str
+    default: /api/docs
+  api_key:
+    description:
+      - Key of the PowerDNS API.
+    type: str
+    required: true
+  keep:
+    description:
+      - Whether or not to keep existing records.
+    type: bool
+    default: false
+  ttl:
+    description:
+      - TTL of the records, in seconds.
+    type: int
+    default: 3600
+  type:
+    description:
+      - Type of resource record (e.g. A, PTR, NSEC...).
+      - Required if O(state=absent) or O(state=present) and none of the record types options are
+        provided.
+    type: str
+  records:
+    description:
+      - Represents a list of records.
+      - Required if O(type) and O(state=present).
+    type: list
+    elements: dict
+    suboptions:
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+      content:
+        description:
+          - The content of resource record.
+        type: str
+        required: true
+  A:
+    description:
+      - Record of type A.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      address:
+        description:
+          - IPv4 address.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  AAAA:
+    description:
+      - Record of type AAAA.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      address:
+        description:
+          - IPv6 address.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  CAA:
+    description:
+      - Certificate Authority Authorization record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      flags:
+        description:
+          - Critical flag for CAA record.
+        type: int
+        default: 0
+        choices: [0, 1]
+      tag:
+        description:
+          - Property tag for CAA record.
+        type: str
+        required: true
+        choices: ["issue", "issuewild", "iodef"]
+      value:
+        description:
+          - Property value for CAA record.
+        type: raw
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  CNAME:
+    description:
+      - Canonical name record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      cname:
+        description:
+          - Canonical domain name.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  DNSKEY:
+    description:
+      - DNS Key record for DNSSEC.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      flags:
+        description:
+          - Key flags field.
+        type: int
+        required: true
+        choices: [256, 257]
+      protocol:
+        description:
+          - Protocol field.
+        type: int
+        required: true
+        choices: [3]
+      algorithm:
+        description:
+          - Algorithm used for the key.
+        type: int
+        required: true
+      public_key:
+        description:
+          - Base64 encoded public key.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  DS:
+    description:
+      - Delegation Signer record for DNSSEC.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      key_tag:
+        description:
+          - Key tag field.
+        type: int
+        required: true
+      algorithm:
+        description:
+          - Algorithm used for signing.
+        type: int
+        required: true
+      digest_type:
+        description:
+          - Digest algorithm type.
+        type: int
+        required: true
+        choices: [1, 2, 3, 4]
+      digest:
+        description:
+          - Digest value.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  HINFO:
+    description:
+      - Host information record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      cpu:
+        description:
+          - CPU type.
+        type: raw
+        required: true
+      os:
+        description:
+          - Operating system.
+        type: raw
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  HTTPS:
+    description:
+      - HTTPS service binding record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      priority:
+        description:
+          - Priority of the target host.
+        type: int
+        required: true
+      target:
+        description:
+          - Target hostname.
+        type: str
+        required: true
+      params:
+        description:
+          - Service parameters.
+        type: str
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  LOC:
+    description:
+      - Location record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      latitude:
+        description:
+          - Latitude coordinate.
+        type: str
+        required: true
+      longitude:
+        description:
+          - Longitude coordinate.
+        type: str
+        required: true
+      altitude:
+        description:
+          - Altitude coordinate.
+        type: str
+        required: true
+      size:
+        description:
+          - Size of the location.
+        type: str
+        default: "1.0m"
+      horizontal_precision:
+        description:
+          - Horizontal precision.
+        type: str
+        default: "10000.0m"
+      vertical_precision:
+        description:
+          - Vertical precision.
+        type: str
+        default: "10.0m"
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  MX:
+    description:
+      - Mail exchange record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      preference:
+        description:
+          - Priority preference for mail delivery.
+        type: int
+        required: true
+      exchange:
+        description:
+          - Mail server hostname.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  NAPTR:
+    description:
+      - Name Authority Pointer record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      order:
+        description:
+          - Order field for processing records.
+        type: int
+        required: true
+      preference:
+        description:
+          - Preference field for records with same order.
+        type: int
+        required: true
+      flags:
+        description:
+          - Flags field.
+        type: raw
+        required: true
+      services:
+        description:
+          - Services field.
+        type: raw
+        required: true
+      regexp:
+        description:
+          - Regular expression for substitution.
+        type: raw
+        required: true
+      replacement:
+        description:
+          - Replacement domain name.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  NS:
+    description:
+      - Name server record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      host:
+        description:
+          - Name server hostname.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  NSEC:
+    description:
+      - Next Secure record for DNSSEC.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      next_domain:
+        description:
+          - Next domain name in canonical order.
+        type: str
+        required: true
+      type_bitmap:
+        description:
+          - Bitmap of record types present.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  NSEC3PARAM:
+    description:
+      - NSEC3 parameters record for DNSSEC.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      hash_algorithm:
+        description:
+          - Hash algorithm used.
+        type: int
+        required: true
+        choices: [1]
+      flags:
+        description:
+          - Flags field.
+        type: int
+        required: true
+        choices: [0, 1]
+      iterations:
+        description:
+          - Number of hash iterations.
+        type: int
+        required: true
+      salt:
+        description:
+          - Salt value for hashing.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  PTR:
+    description:
+      - Pointer record for reverse DNS lookup.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      ptrdname:
+        description:
+          - Domain name for reverse lookup.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  RP:
+    description:
+      - Responsible person record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      mbox:
+        description:
+          - Mailbox domain name of responsible person.
+        type: str
+        required: true
+      txt:
+        description:
+          - Domain name for TXT record with contact info.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  SPF:
+    description:
+      - Sender Policy Framework record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      strings:
+        description:
+          - SPF policy strings.
+        type: raw
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  SOA:
+    description:
+      - Start of Authority record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      mname:
+        description:
+          - Primary master name server.
+        type: str
+        required: true
+      rname:
+        description:
+          - Email address of zone administrator.
+        type: str
+        required: true
+      serial:
+        description:
+          - Serial number of the zone.
+        type: int
+      refresh:
+        description:
+          - Refresh interval in seconds.
+        type: int
+      retry:
+        description:
+          - Retry interval in seconds.
+        type: int
+      expire:
+        description:
+          - Expire time in seconds.
+        type: int
+      minimum:
+        description:
+          - Minimum TTL in seconds.
+        type: int
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  SRV:
+    description:
+      - Service record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      priority:
+        description:
+          - Priority of the target host.
+        type: int
+        required: true
+      weight:
+        description:
+          - Relative weight for records with same priority.
+        type: int
+        required: true
+      port:
+        description:
+          - TCP or UDP port number.
+        type: int
+        required: true
+      target:
+        description:
+          - Target hostname.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  SSHFP:
+    description:
+      - SSH fingerprint record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      algorithm:
+        description:
+          - SSH key algorithm.
+        type: int
+        required: true
+        choices: [1, 2, 3, 4, 6]
+      fp_type:
+        description:
+          - Fingerprint type.
+        type: int
+        required: true
+        choices: [1, 2, 3]
+      fingerprint:
+        description:
+          - SSH key fingerprint.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  SVCB:
+    description:
+      - Service binding record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      priority:
+        description:
+          - Priority of the target host.
+        type: int
+        required: true
+      target:
+        description:
+          - Target hostname.
+        type: str
+        required: true
+      params:
+        description:
+          - Service parameters.
+        type: str
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  TLSA:
+    description:
+      - Transport Layer Security Authentication record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      usage:
+        description:
+          - Certificate usage.
+        type: int
+        required: true
+        choices: [0, 1, 2, 3]
+      selector:
+        description:
+          - Selector field.
+        type: int
+        required: true
+        choices: [0, 1]
+      matching_type:
+        description:
+          - Matching type.
+        type: int
+        required: true
+        choices: [0, 1, 2]
+      cert_assoc_data:
+        description:
+          - Certificate association data.
+        type: str
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+  TXT:
+    description:
+      - Text record.
+      - Required if O(state=present) or O(state=absent) and O(type) and O(records)
+        and any of the other record type option not present.
+    type: list
+    elements: dict
+    suboptions:
+      strings:
+        description:
+          - Text strings.
+        type: raw
+        required: true
+      disabled:
+        description:
+          - Whether or not this record is disabled.
+        type: bool
+        default: false
+
+
+author: Mohamed Chamrouk (@mohamed-chamrouk)
+"""
+
+EXAMPLES = """
+%YAML 1.2
+---
+- name: Creating a rrset of record type A
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    type: A
+    records:
+      - content: 192.168.0.1
+
+- name: Creating a rrset of record type A
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    A:
+      - address: 192.168.0.1
+
+- name: Deleting rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    type: A
+
+- name: Replacing records in rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    A:
+      - address: 192.168.1.1
+
+- name: Updating records in rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    keep: true
+    NS:
+      - host: ns1.example.
+
+- name: Deleting records in rrset
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    name: ns.zone.example.
+    state: absent
+    keep: true
+    NS:
+      - host: ns1.example.
+
+- name: Listing all rrsets in zone
+  kpfleming.powerdns_auth.rrset:
+    api_key: foo
+    zone_name: zone.example.
+    state: exists
+"""
+
+RETURN = """
+%YAML 1.2
+---
+name:
+  description: name of the rrset
+  returned: always
+  type: str
+  sample: rrset.example.
+exists:
+  description: whether the provided name and type lead to existing rrset(s)
+  returned: when state is exists and name and/or type provided
+  type: bool
+rrset:
+  description: single rrset resource
+  returned: when state is exists and name and type are provided
+  type: dict
+  contains:
+    comments:
+      description:
+        - list of comments on the rrset
+      type: list
+      elements: str
+    name:
+      description:
+        - name of the rrset
+      type: str
+    records:
+      description:
+        - list of the records
+      type: list
+      elements: str
+    ttl:
+      description:
+        - TTL of the records, in seconds.
+      type: int
+    type:
+      description:
+        - type of the record
+      type: str
+rrsets:
+  description: list of existing rrsets or rrsets after changes are made
+  returned: always except when rrset conditions are fulfilled
+  type: list
+  elements: dict
+  contains:
+    comments:
+      description:
+        - list of comments on the rrset
+      type: list
+      elements: str
+    name:
+      description:
+        - name of the rrset
+      type: str
+    records:
+      description:
+        - list of the records
+      type: list
+      elements: str
+    ttl:
+      description:
+        - TTL of the records, in seconds.
+      type: int
+    type:
+      description:
+        - type of the record
+      type: str
+"""
+
+
+class APIZoneRRSetWrapper(APIWrapper):
+    def __init__(self, *, module, result, object_type, zone_id):
+        super().__init__(module=module, result=result, object_type=object_type)
+        self.zone_id = zone_id
+
+    @api_exception_handler
+    def listZone(self):  # noqa: N802
+        return self.raw_api.listZone(
+            server_id=self.server_id,
+            zone_id=self.zone_id,
+            rrsets=True,
+        ).result()
+
+    @api_exception_handler
+    def listZones(self, **kwargs):  # noqa: N802
+        return self.raw_api.listZones(server_id=self.server_id, **kwargs).result()
+
+    @api_exception_handler
+    def patchZone(self, **kwargs):  # noqa: N802
+        return self.raw_api.patchZone(
+            server_id=self.server_id,
+            zone_id=self.zone_id,
+            **kwargs,
+        ).result()
+
+
+def get_result_rrsets(rrsets, rrset_name, rrset_type):
+    """
+    Function to build the return object to the ansible module.
+    rrsets refers to the existings rrsets.
+    rrset_name and rrset_type can be None, if provided it will filter rrsets based on those.
+    """
+    r = {
+        "rrsets": rrsets,
+    }
+
+    if rrset_name is not None:
+        if rrset_type is not None:
+            r = {
+                "exists": False,
+                "rrset": {},
+            }
+            for rrset in rrsets:
+                if rrset["name"] == rrset_name and rrset["type"] == rrset_type:
+                    r = {
+                        "exists": True,
+                        "rrset": rrset,
+                    }
+        else:
+            r = {
+                "exists": False,
+                "rrsets": [],
+            }
+            for rrset in rrsets:
+                if rrset["name"] == rrset_name:
+                    r["rrsets"] += [rrset]
+                    r["exists"] = True
+    elif rrset_type is not None:
+        r = {
+            "exists": False,
+            "rrsets": [],
+        }
+        for rrset in rrsets:
+            if rrset["type"] == rrset_type:
+                r["rrsets"] += [rrset]
+                r["exists"] = True
+
+    return r
+
+
+def get_rrsets(api_client):
+    return api_client.listZone()["rrsets"]
+
+
+def safe_string_record(record_type, record, type_def):
+    """
+    PowerDNS expects some field of some records to have quotes.
+    Said fields have type "raw", allowing for filtering.
+    """
+    record_spec = type_def[record_type]
+
+    safe_record = record
+
+    for field in record_spec["options"].items():
+        if field[0] in record and field[1]["type"] == "raw":
+            value = safe_record[field[0]]
+            safe_record[field[0]] = '"' + value.removeprefix('"').removesuffix('"') + '"'
+
+    return safe_record
+
+
+def main():
+    module_args = {
+        "state": {
+            "type": "str",
+            "default": "present",
+            "choices": ["present", "absent", "exists"],
+        },
+        "name": {
+            "type": "str",
+        },
+        "zone_name": {
+            "type": "str",
+            "required": True,
+        },
+        "server_id": {
+            "type": "str",
+            "default": "localhost",
+        },
+        "api_url": {
+            "type": "str",
+            "default": "http://localhost:8081",
+        },
+        "api_spec_path": {
+            "type": "str",
+            "default": "/api/docs",
+        },
+        "api_key": {
+            "type": "str",
+            "required": True,
+            "no_log": True,
+        },
+        "keep": {
+            "type": "bool",
+            "default": False,
+        },
+        "ttl": {
+            "type": "int",
+            "default": 3600,
+        },
+        "type": {
+            "type": "str",
+        },
+        "records": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "disabled": {
+                    "type": "bool",
+                    "default": False,
+                },
+                "content": {
+                    "type": "str",
+                    "required": True,
+                },
+            },
+        },
+        "A": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "address": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "AAAA": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "address": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "CAA": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "flags": {"type": "int", "required": False, "default": 0, "choices": [0, 1]},
+                "tag": {
+                    "type": "str",
+                    "required": True,
+                    "choices": ["issue", "issuewild", "iodef"],
+                },
+                "value": {"type": "raw", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "CNAME": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "cname": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "DNSKEY": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "flags": {"type": "int", "required": True, "choices": [256, 257]},
+                "protocol": {"type": "int", "required": True, "choices": [3]},
+                "algorithm": {"type": "int", "required": True},
+                "public_key": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "DS": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "key_tag": {"type": "int", "required": True},
+                "algorithm": {"type": "int", "required": True},
+                "digest_type": {"type": "int", "required": True, "choices": [1, 2, 3, 4]},
+                "digest": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "HINFO": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "cpu": {"type": "raw", "required": True},
+                "os": {"type": "raw", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "HTTPS": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "priority": {"type": "int", "required": True},
+                "target": {"type": "str", "required": True},
+                "params": {"type": "str", "required": False},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "LOC": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "latitude": {"type": "str", "required": True},
+                "longitude": {"type": "str", "required": True},
+                "altitude": {"type": "str", "required": True},
+                "size": {"type": "str", "required": False, "default": "1.0m"},
+                "horizontal_precision": {"type": "str", "required": False, "default": "10000.0m"},
+                "vertical_precision": {"type": "str", "required": False, "default": "10.0m"},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "MX": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "preference": {"type": "int", "required": True},
+                "exchange": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "NAPTR": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "order": {"type": "int", "required": True},
+                "preference": {"type": "int", "required": True},
+                "flags": {"type": "raw", "required": True},
+                "services": {"type": "raw", "required": True},
+                "regexp": {"type": "raw", "required": True},
+                "replacement": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "NS": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "host": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "NSEC": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "next_domain": {"type": "str", "required": True},
+                "type_bitmap": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "NSEC3PARAM": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "hash_algorithm": {"type": "int", "required": True, "choices": [1]},
+                "flags": {"type": "int", "required": True, "choices": [0, 1]},
+                "iterations": {"type": "int", "required": True},
+                "salt": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "PTR": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "ptrdname": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "RP": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "mbox": {"type": "str", "required": True},
+                "txt": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "SPF": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "strings": {"type": "raw", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "SOA": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "mname": {"type": "str", "required": True},
+                "rname": {"type": "str", "required": True},
+                "serial": {"type": "int", "required": False},
+                "refresh": {"type": "int", "required": False},
+                "retry": {"type": "int", "required": False},
+                "expire": {"type": "int", "required": False},
+                "minimum": {"type": "int", "required": False},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "SRV": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "priority": {"type": "int", "required": True},
+                "weight": {"type": "int", "required": True},
+                "port": {"type": "int", "required": True},
+                "target": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "SSHFP": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "algorithm": {"type": "int", "required": True, "choices": [1, 2, 3, 4, 6]},
+                "fp_type": {"type": "int", "required": True, "choices": [1, 2, 3]},
+                "fingerprint": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "SVCB": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "priority": {"type": "int", "required": True},
+                "target": {"type": "str", "required": True},
+                "params": {"type": "str", "required": False},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "TLSA": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "usage": {"type": "int", "required": True, "choices": [0, 1, 2, 3]},
+                "selector": {"type": "int", "required": True, "choices": [0, 1]},
+                "matching_type": {"type": "int", "required": True, "choices": [0, 1, 2]},
+                "cert_assoc_data": {"type": "str", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+        "TXT": {
+            "type": "list",
+            "elements": "dict",
+            "options": {
+                "strings": {"type": "raw", "required": True},
+                "disabled": {"type": "bool", "required": False, "default": False},
+            },
+        },
+    }
+
+    record_types = [
+        "A",
+        "AAAA",
+        "CAA",
+        "CNAME",
+        "DNSKEY",
+        "DS",
+        "HINFO",
+        "HTTPS",
+        "LOC",
+        "MX",
+        "NAPTR",
+        "NS",
+        "NSEC",
+        "NSEC3PARAM",
+        "PTR",
+        "RP",
+        "SPF",
+        "SOA",
+        "SRV",
+        "SSHFP",
+        "SVCB",
+        "TLSA",
+        "TXT",
+    ]
+
+    # mutually_exclusive: prevent use of type and A,AAAA... at the same time
+    # require_if: if state is absent, one of type, A, AAAA is required and so on
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        mutually_exclusive=[(record_type, "records") for record_type in record_types]
+        + [(record_type, "type") for record_type in record_types],
+        required_if=[
+            ("state", "absent", [*record_types, "type"], True),
+            ("state", "present", ["name"]),
+            ("state", "absent", ["name"]),
+            ("state", "present", [*record_types, "type"], True),
+        ],
+    )
+
+    state = module.params["state"]
+    zone_name = module.params["zone_name"]
+
+    result = {
+        "changed": False,
+    }
+
+    # create an object to proxy the raw API object
+    # and carry the server_id into all API calls
+    # automatically, along with handling
+    # predictable exceptions
+    api_client = APIZoneRRSetWrapper(
+        module=module, result=result, object_type="zones", zone_id=None
+    )
+
+    partial_zone_info = api_client.listZones(zone=zone_name)
+
+    if len(partial_zone_info) == 0:
+        module.fail_json(f"Failed to find zone named {zone_name}")
+
+    # get the zone_id from the zone_name
+    zone_id = partial_zone_info[0]["id"]
+    api_client.zone_id = zone_id
+    params = module.params
+
+    result.update({"name": params["name"]})
+
+    zone_rrsets = get_rrsets(api_client)
+    result_rrsets = get_result_rrsets(zone_rrsets, params["name"], params["type"])
+
+    if state == "exists":
+        result.update(result_rrsets)
+        module.exit_json(**result)
+
+    changetype = "REPLACE" if state == "present" else "DELETE"
+    # The following variable refers to the DNS Record types options (A,AAAA,CAA...)
+    rrset_record_types = set(p for p in params if params[p] is not None) & set(record_types)  # noqa: C401
+
+    # Check couldn't fit in AnsibleModule args
+    type_classic = "type" in params and "records" in params
+    if params["state"] == "present" and not (type_classic or rrset_record_types):
+        module.fail_json("State is present but no valid record has been provided")
+
+    if rrset_record_types:
+        rrset_records = [
+            {
+                "type": record_type,
+                "records": [
+                    safe_string_record(
+                        record_type, record, {t: module_args[t] for t in record_types}
+                    )
+                    for record in params[record_type]
+                ],
+            }
+            for record_type in rrset_record_types
+        ]
+
+        rrsets_struct = []
+        records = []
+
+        for rrset in rrset_records:
+            for record in rrset["records"]:
+                disabled = record.pop("disabled")
+                records += [{"disabled": disabled, "content": " ".join(map(str, record.values()))}]
+
+            rrsets_struct += [
+                {
+                    "name": params["name"].lower(),
+                    "type": rrset["type"],
+                    "ttl": params["ttl"],
+                    "keep": params["keep"],
+                    "changetype": changetype,
+                    "records": records,
+                }
+            ]
+
+            records = []
+    else:
+        rrsets_struct = [
+            {
+                "name": params["name"].lower(),
+                "type": params["type"],
+                "ttl": params["ttl"],
+                "keep": params["keep"],
+                "changetype": changetype,
+                "records": params.get("records", []),
+            }
+        ]
+
+    zone_struct = {}
+
+    for rrset in rrsets_struct:
+        # Retrieving existing rrset, there can only be one
+        # that matches "name" and "type" values.
+        existing_rrset = next(
+            (r for r in zone_rrsets if r["name"] == rrset["name"] and r["type"] == rrset["type"]),
+            None,
+        )
+
+        rrset_changetype = rrset["changetype"]
+        rrset_keep = rrset.pop(
+            "keep"
+        )  # Keeping the option out for cleaner zone_struct on subsequent unpacking
+
+        if not existing_rrset or not rrset_keep:
+            if rrset_changetype == "REPLACE":
+                # For REPLACE, not wanting to keep existing records or not having any existing
+                # records is the same
+                if rrset["type"] is not None:
+                    zone_struct.setdefault("rrsets", []).append(rrset)
+                else:
+                    module.fail_json("No valid record found for rrset creation.")
+            elif rrset_changetype == "DELETE":
+                if existing_rrset:
+                    zone_struct.setdefault("rrsets", []).append(rrset)
+                else:
+                    module.fail_json(
+                        f"No matching rrset found for name: {rrset['name']} \
+                          and type: {rrset['type']}"
+                    )
+        elif rrset["records"] == existing_rrset["records"]:
+            # Despite keep being present, if existing records and given ones match
+            # exactly then for changetype="DELETE",
+            # the final operation is to delete the whole rrset.
+            # If the changetype is "REPLACE",
+            # nothing is done for the rest of the rrset
+            if rrset_changetype == "DELETE":
+                # Using .setdefault to avoid creating a key on zone_struct dict
+                # and keep the dict empty for idempotency
+                zone_struct.setdefault("rrsets", []).append(
+                    {
+                        "name": rrset["name"],
+                        "type": rrset["type"],
+                        "changetype": "DELETE",
+                    }
+                )
+        else:
+            if rrset_changetype == "REPLACE":
+                # Building a list of unique union of existing and provided records
+                new_records_list = existing_rrset["records"] + [
+                    record for record in rrset["records"] if record not in existing_rrset["records"]
+                ]
+            else:
+                # Building a list of remaining records
+                # after removing provided ones from existing ones
+                new_records_list = [] + [
+                    r for r in existing_rrset["records"] if r not in rrset["records"]
+                ]
+
+            if new_records_list != existing_rrset["records"]:
+                zone_struct.setdefault("rrsets", []).append(
+                    {
+                        **rrset,
+                        "records": new_records_list,
+                        "changetype": "REPLACE",
+                    }
+                )
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    if zone_struct:
+        api_client.patchZone(zone_struct=zone_struct)
+        result["changed"] = True
+        result["rrsets"] = get_rrsets(api_client)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow-support/ansible-2.15/lookup_plugins/dig_local.py
+++ b/workflow-support/ansible-2.15/lookup_plugins/dig_local.py
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
             - C(CAA) has been added in community.general 6.3.0.
         type: str
         default: 'A'
-        choices: [A, ALL, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC, MX, NAPTR, NS, NSEC3PARAM, PTR, RP, RRSIG, SOA, SPF, SRV, SSHFP, TLSA, TXT]
+        choices: [A, ALL, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, HTTPS, LOC, MX, NAPTR, NS, NSEC, NSEC3PARAM, PTR, RP, RRSIG, SOA, SPF, SRV, SSHFP, SVCB, TLSA, TXT]
       flat:
         description: If 0 each record is returned as a dictionary, otherwise a string.
         type: int
@@ -205,8 +205,9 @@ try:
     import dns.resolver
     import dns.reversename
     import dns.rdataclass
-    from dns.rdatatype import (A, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC,
-                               MX, NAPTR, NS, NSEC3PARAM, PTR, RP, SOA, SPF, SRV, SSHFP, TLSA, TXT)
+    from dns.rdatatype import (A, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, HTTPS, LOC, MX,
+                               NAPTR, NS, NSEC, NSEC3PARAM, PTR, RP, SOA, SPF, SRV, SSHFP,
+                               SVCB, TLSA, TXT)
     HAVE_DNS = True
 except ImportError:
     HAVE_DNS = False
@@ -231,10 +232,12 @@ def make_rdata_dict(rdata):
         DNSKEY: ['flags', 'algorithm', 'protocol', 'key'],
         DS: ['algorithm', 'digest_type', 'key_tag', 'digest'],
         HINFO: ['cpu', 'os'],
+        HTTPS: ['priority', 'target', 'params'],
         LOC: ['latitude', 'longitude', 'altitude', 'size', 'horizontal_precision', 'vertical_precision'],
         MX: ['preference', 'exchange'],
         NAPTR: ['order', 'preference', 'flags', 'service', 'regexp', 'replacement'],
         NS: ['target'],
+        NSEC: ['next', 'windows'],
         NSEC3PARAM: ['algorithm', 'flags', 'iterations', 'salt'],
         PTR: ['target'],
         RP: ['mbox', 'txt'],
@@ -243,6 +246,7 @@ def make_rdata_dict(rdata):
         SPF: ['strings'],
         SRV: ['priority', 'weight', 'port', 'target'],
         SSHFP: ['algorithm', 'fp_type', 'fingerprint'],
+        SVCB: ['priority', 'target', 'params'],
         TLSA: ['usage', 'selector', 'mtype', 'cert'],
         TXT: ['strings'],
     }

--- a/workflow-support/ansible-2.15/rrset-vars.yml
+++ b/workflow-support/ansible-2.15/rrset-vars.yml
@@ -1,0 +1,1 @@
+../ansible-2.19/rrset-vars.yml

--- a/workflow-support/ansible-2.15/template/all-rrset-types.yml.j2
+++ b/workflow-support/ansible-2.15/template/all-rrset-types.yml.j2
@@ -1,0 +1,41 @@
+{% for rrset in rrsets %}
+{% set rrset_type = rrset.keys() | first %}
+- name: Creating rrset of type {{ rrset_type }}
+  kpfleming.powerdns_auth.rrset:
+    {% if rrset_type in ["DNSKEY", "NS", "NSEC"] %}
+        {% set name = "rrset.example." %}
+    {% else %}
+        {% set name = "t." ~ rrset_type ~ ".rrset.example." %}
+    {% endif %}
+    {% set params = {
+        "zone_name": "rrset.example.",
+        "name": name,
+        "state": "present",
+        "api_key": api_key
+        }
+    %}
+    {{ params | combine(rrset) }}
+  register: result
+
+- ansible.builtin.assert:
+    quiet: true
+    that:
+      - result['exception'] is not defined
+      - not result.failed
+      - result.changed
+      - rrset != "NXDOMAIN"
+      - >
+        ( rrset is not string and ( rrset | map(attribute='type') | unique | list ) == ["{{ rrset_type }}"])
+        or
+        ( rrset is string )
+      - >
+        ( rrset is not string and ( rrset | map(attribute='ttl') | unique | list ) == [3600])
+        or
+        ( rrset is string )
+      - >
+        ( rrset is not string and ( rrset | map(attribute='owner') | unique | list ) == ["{{ name }}"])
+        or
+        ( rrset is string )
+  vars:
+    rrset: "{% raw %}{{ query('dig_local', '{% endraw %}{{ name }}{% raw %}', qtype='{% endraw %}{{ rrset_type }}{% raw %}', flat=0, fail_on_error=false, real_empty=false) }}{% endraw %}"
+{% endfor %}

--- a/workflow-support/ansible-2.15/template/all-rrset-types.yml.j2
+++ b/workflow-support/ansible-2.15/template/all-rrset-types.yml.j2
@@ -1,7 +1,8 @@
 {% for rrset in rrsets %}
 {% set rrset_type = rrset.keys() | first %}
-- name: Creating rrset of type {{ rrset_type }}
+- name: Creating RRset of type {{ rrset_type }}
   kpfleming.powerdns_auth.rrset:
+    {# The following types require the RR to be in the root of the zone #}
     {% if rrset_type in ["DNSKEY", "NS", "NSEC"] %}
         {% set name = "rrset.example." %}
     {% else %}

--- a/workflow-support/ansible-2.15/template/all-rrset-types.yml.j2
+++ b/workflow-support/ansible-2.15/template/all-rrset-types.yml.j2
@@ -3,7 +3,7 @@
 - name: Creating RRset of type {{ rrset_type }}
   kpfleming.powerdns_auth.rrset:
     {# The following types require the RR to be in the root of the zone #}
-    {% if rrset_type in ["DNSKEY", "NS", "NSEC"] %}
+    {% if rrset_type in ["DNSKEY", "NS"] %}
         {% set name = "rrset.example." %}
     {% else %}
         {% set name = "t." ~ rrset_type ~ ".rrset.example." %}

--- a/workflow-support/ansible-2.15/template/test-rrset-all-dnssec-types.yml
+++ b/workflow-support/ansible-2.15/template/test-rrset-all-dnssec-types.yml
@@ -1,0 +1,1 @@
+# File to be replaced during template creation, see test-rrset-record.yml file task "Creating template for all RRset dnssec types"

--- a/workflow-support/ansible-2.15/template/test-rrset-all-types.yml
+++ b/workflow-support/ansible-2.15/template/test-rrset-all-types.yml
@@ -1,0 +1,1 @@
+# File to be replaced during template creation, see test-rrset-record.yml file task "Creating template for all RRset types"

--- a/workflow-support/ansible-2.15/test-cryptokey.yml
+++ b/workflow-support/ansible-2.15/test-cryptokey.yml
@@ -119,8 +119,8 @@
         active: true
       register: result
     - <<: *refresh
-    # For the following test : by default, when creating a Cryptokey and it's the only one present
-    # powerdns will use it as a csk regardless of the keytype passed for its creation
+    # For the following test : by default, when creating a unique CryptoKey in a zone,
+    # powerdns will use it as a csk regardless of the keytype passed for its creation.
     # Once another CryptoKey is present of the opposite type or a csk, powerdns will use
     # the two CryptoKeys as a ksk/zsk pair.
     - ansible.builtin.assert:
@@ -254,7 +254,7 @@
         quiet: true
         that:
           - result.failed
-          - result.msg == "Wrong options provided for CryptoKey creation"
+          - "result.msg == 'parameters are required together: dnskey, privatekey'"
 
     - name: check missing keytype
       kpfleming.powerdns_auth.cryptokey:

--- a/workflow-support/ansible-2.15/test-cryptokey.yml
+++ b/workflow-support/ansible-2.15/test-cryptokey.yml
@@ -1,0 +1,289 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    ansible_python_interpreter: python
+    common_args: &common
+      api_key: foo
+      zone_name: cryptokeys.example.
+    refresh_task: &refresh
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        name: cryptokeys.example.
+        NS:
+          - host: ns1.example.
+
+  pre_tasks:
+    - ansible.builtin.debug:
+        var: ansible_python_interpreter
+
+    - name: Creating Native zone for cryptokeys tests
+      kpfleming.powerdns_auth.zone:
+        name: cryptokeys.example.
+        api_key: foo
+        state: present
+        properties:
+          kind: Native
+          nameservers:
+            - ns.example.
+          soa:
+            mname: localhost.
+            rname: hostmaster.localhost.
+          rrsets:
+            - name: cryptokeys.example.
+              type: A
+              records:
+                - content: 192.168.1.1
+      register: result
+
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - result.zone.name == "cryptokeys.example."
+          - result.zone.kind == "Native"
+
+  tasks:
+    - name: check that there are no keys
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: exists
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.exists
+          - not result.changed
+          - result.cryptokey == {}
+          - result.cryptokeys == []
+          - output == ""
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check generated key creation
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          keytype: csk
+          algorithm: ed25519
+          active: true
+      register: result
+    - <<: *refresh
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - (result.cryptokeys | length) == 1
+          - result.cryptokeys[0]["algorithm"].lower() == "ed25519"
+          - result.cryptokeys[0]["active"] == true
+          - result.cryptokeys[0]["keytype"] == "csk"
+          - output["algorithm"] == 15
+          - output["type"] == "DNSKEY"
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=true, real_empty=true) | tojson }}"
+
+    - name: check key deletion
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: absent
+        cryptokey_id: 1
+      register: result
+    - <<: *refresh
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - result.cryptokeys == []
+          - result.cryptokey == {}
+          - output == ""
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check imported key creation
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          keytype: zsk
+          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+          privatekey: "Private-key-format: v1.2\nAlgorithm: 15 (ED25519)\nPrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n"
+          active: true
+      register: result
+    - <<: *refresh
+    # For the following test : by default, when creating a key and it's the only one present
+    # powerdns will use it as a csk regardless of the keytype passed for its creation
+    # Once another key is present of the opposite type or a csk, powerdns will use
+    # the two keys as a ksk/zsk pair.
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - (result.cryptokeys | length) == 1
+          - result.cryptokeys[0]["active"] == true
+          - result.cryptokeys[0]["keytype"] == "csk"
+          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokeys[0]["dnskey"]'
+          - output["key"] == "lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+          - output["algorithm"] == 15
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) | tojson }}"
+
+    - name: check getting key by id
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: exists
+        cryptokey_id: 1
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - result.cryptokey["active"] == true
+          - result.cryptokey["keytype"] == "csk"
+          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokey["dnskey"]'
+
+    - name: check listing of all keys
+      block:
+        - name: creating key
+          kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: present
+            cryptokey:
+              active: false
+              keytype: ksk
+              algorithm: ed25519
+          register: cryptokey
+        - name: getting keys
+          kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: exists
+          register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - (result.cryptokeys | length) == 2
+          - result.cryptokey == {}
+          - cryptokey.changed
+
+    - name: deleting key for following tests
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: absent
+        cryptokey_id: 1
+    - <<: *refresh
+
+    - name: check activating key
+      block:
+        - kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: present
+            cryptokey_id: 2
+            cryptokey:
+              active: true
+          register: cryptokey
+        - kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: "exists"
+            cryptokey_id: 2
+          register: result
+    - <<: *refresh
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - cryptokey['exception'] is not defined
+          - result['exception'] is not defined
+          - not cryptokey.failed
+          - not result.failed
+          - result.cryptokey.active == true
+          - output["algorithm"] == 15
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) | tojson }}"
+
+    - name: check getting key by id of nonexistent key
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: exists
+        cryptokey_id: 100
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - not result.exists
+          - result.msg == "API operation getCryptokey returned 'Not Found'"
+
+    - name: check operation on nonexistent zone
+      kpfleming.powerdns_auth.cryptokey:
+        api_key: foo
+        zone_name: nonexistent.example.
+        state: exists
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - result.msg == "No zone found for name nonexistent.example."
+
+    - name: check imported key with wrong parameters
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          keytype: zsk
+          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+          active: true
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - result.msg == "Wrong options provided for cryptokey creation"
+
+    - name: check missing keytype
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          algorithm: ed25519
+          active: true
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - result.msg == "Missing keytype option in cryptokey definition"
+
+    - name: check nonexistent key deletion
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: absent
+        cryptokey_id: 100
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - result.msg == "Key of id 100 not found for zone cryptokeys.example."

--- a/workflow-support/ansible-2.15/test-cryptokey.yml
+++ b/workflow-support/ansible-2.15/test-cryptokey.yml
@@ -7,6 +7,9 @@
     common_args: &common
       api_key: foo
       zone_name: cryptokeys.example.
+    # For some reason in this test environment changes made to the CryptoKeys
+    # are not effective unless some record is updated in the zone hence the following
+    # task and its presence throughout the playbook.
     refresh_task: &refresh
       kpfleming.powerdns_auth.rrset:
         <<: *common
@@ -18,7 +21,7 @@
     - ansible.builtin.debug:
         var: ansible_python_interpreter
 
-    - name: Creating Native zone for cryptokeys tests
+    - name: Creating Native zone for CryptoKeys tests
       kpfleming.powerdns_auth.zone:
         name: cryptokeys.example.
         api_key: foo
@@ -47,7 +50,7 @@
           - result.zone.kind == "Native"
 
   tasks:
-    - name: check that there are no keys
+    - name: check that there are no CryptoKeys
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: exists
@@ -59,20 +62,18 @@
           - not result.failed
           - not result.exists
           - not result.changed
-          - result.cryptokey == {}
           - result.cryptokeys == []
           - output == ""
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check generated key creation
+    - name: check generated CryptoKey creation
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          keytype: csk
-          algorithm: ed25519
-          active: true
+        keytype: csk
+        algorithm: ed25519
+        active: true
       register: result
     - <<: *refresh
     - ansible.builtin.assert:
@@ -90,11 +91,11 @@
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=true, real_empty=true) | tojson }}"
 
-    - name: check key deletion
+    - name: check CryptoKey deletion
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: absent
-        cryptokey_id: 1
+        id: 1
       register: result
     - <<: *refresh
     - ansible.builtin.assert:
@@ -104,26 +105,24 @@
           - not result.failed
           - result.changed
           - result.cryptokeys == []
-          - result.cryptokey == {}
           - output == ""
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check imported key creation
+    - name: check imported CryptoKey creation
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          keytype: zsk
-          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
-          privatekey: "Private-key-format: v1.2\nAlgorithm: 15 (ED25519)\nPrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n"
-          active: true
+        keytype: zsk
+        dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+        privatekey: "Private-key-format: v1.2\nAlgorithm: 15 (ED25519)\nPrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n"
+        active: true
       register: result
     - <<: *refresh
-    # For the following test : by default, when creating a key and it's the only one present
+    # For the following test : by default, when creating a Cryptokey and it's the only one present
     # powerdns will use it as a csk regardless of the keytype passed for its creation
-    # Once another key is present of the opposite type or a csk, powerdns will use
-    # the two keys as a ksk/zsk pair.
+    # Once another CryptoKey is present of the opposite type or a csk, powerdns will use
+    # the two CryptoKeys as a ksk/zsk pair.
     - ansible.builtin.assert:
         quiet: true
         that:
@@ -139,11 +138,11 @@
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) | tojson }}"
 
-    - name: check getting key by id
+    - name: check getting CryptoKey by id
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: exists
-        cryptokey_id: 1
+        id: 1
       register: result
     - ansible.builtin.assert:
         quiet: true
@@ -152,20 +151,20 @@
           - not result.failed
           - not result.changed
           - result.exists
-          - result.cryptokey["active"] == true
-          - result.cryptokey["keytype"] == "csk"
-          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokey["dnskey"]'
+          - (result.cryptokeys | length) == 1
+          - result.cryptokeys[0]["active"] == true
+          - result.cryptokeys[0]["keytype"] == "csk"
+          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokeys[0]["dnskey"]'
 
-    - name: check listing of all keys
+    - name: check listing of all CryptoKeys
       block:
         - name: creating key
           kpfleming.powerdns_auth.cryptokey:
             <<: *common
             state: present
-            cryptokey:
-              active: false
-              keytype: ksk
-              algorithm: ed25519
+            active: false
+            keytype: ksk
+            algorithm: ed25519
           register: cryptokey
         - name: getting keys
           kpfleming.powerdns_auth.cryptokey:
@@ -180,29 +179,27 @@
           - not result.changed
           - result.exists
           - (result.cryptokeys | length) == 2
-          - result.cryptokey == {}
           - cryptokey.changed
 
-    - name: deleting key for following tests
+    - name: deleting CryptoKey for following tests
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: absent
-        cryptokey_id: 1
+        id: 1
     - <<: *refresh
 
-    - name: check activating key
+    - name: check activating CryptoKey
       block:
         - kpfleming.powerdns_auth.cryptokey:
             <<: *common
             state: present
-            cryptokey_id: 2
-            cryptokey:
-              active: true
+            id: 2
+            active: true
           register: cryptokey
         - kpfleming.powerdns_auth.cryptokey:
             <<: *common
             state: "exists"
-            cryptokey_id: 2
+            id: 2
           register: result
     - <<: *refresh
     - ansible.builtin.assert:
@@ -212,16 +209,16 @@
           - result['exception'] is not defined
           - not cryptokey.failed
           - not result.failed
-          - result.cryptokey.active == true
+          - result.cryptokeys[0]['active'] == true
           - output["algorithm"] == 15
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) | tojson }}"
 
-    - name: check getting key by id of nonexistent key
+    - name: check getting CryptoKey by id of nonexistent CryptoKey
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: exists
-        cryptokey_id: 100
+        id: 100
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -244,42 +241,40 @@
           - result.failed
           - result.msg == "No zone found for name nonexistent.example."
 
-    - name: check imported key with wrong parameters
+    - name: check imported CryptoKey with wrong parameters
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          keytype: zsk
-          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
-          active: true
+        keytype: zsk
+        dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+        active: true
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
         quiet: true
         that:
           - result.failed
-          - result.msg == "Wrong options provided for cryptokey creation"
+          - result.msg == "Wrong options provided for CryptoKey creation"
 
     - name: check missing keytype
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          algorithm: ed25519
-          active: true
+        algorithm: ed25519
+        active: true
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
         quiet: true
         that:
           - result.failed
-          - result.msg == "Missing keytype option in cryptokey definition"
+          - result.msg == "Missing keytype option in CryptoKey definition"
 
-    - name: check nonexistent key deletion
+    - name: check nonexistent CryptoKey deletion
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: absent
-        cryptokey_id: 100
+        id: 100
       ignore_errors: true
       register: result
     - ansible.builtin.assert:

--- a/workflow-support/ansible-2.15/test-rrset-record.yml
+++ b/workflow-support/ansible-2.15/test-rrset-record.yml
@@ -17,7 +17,7 @@
     - ansible.builtin.debug:
         var: ansible_python_interpreter
 
-    - name: Creating template for all rrset types
+    - name: Creating template for all RRset types
       ansible.builtin.template:
         src: ./template/all-rrset-types.yml.j2
         dest: ./template/test-rrset-all-types.yml
@@ -26,7 +26,7 @@
     - ansible.builtin.set_fact:
         rrsets: "{{ rrsets_dnssec }}"
 
-    - name: Creating template for all rrset dnssec types
+    - name: Creating template for all RRset dnssec types
       ansible.builtin.template:
         src: ./template/all-rrset-types.yml.j2
         dest: ./template/test-rrset-all-dnssec-types.yml
@@ -56,15 +56,15 @@
           - result.zone.kind == "Native"
 
   tasks:
-    - name: check creating each type of supported DNS record
+    - name: check creating each type of supported DNS RR
       ansible.builtin.include_tasks:
         file: ./template/test-rrset-all-types.yml
 
-    - name: check creating each type of supported DNSSEC record
+    - name: check creating each type of supported DNSSEC RR
       ansible.builtin.include_tasks:
         file: ./template/test-rrset-all-dnssec-types.yml
 
-    - name: check deleting existing rrset
+    - name: check deleting existing RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -81,7 +81,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.hinfo.rrset.example.', qtype='HINFO', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check updating existing rrset by replacing all records
+    - name: check updating existing RRset by replacing all RRs
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -102,7 +102,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.aaaa.rrset.example.', qtype='AAAA', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check updating existing rrset and keeping records
+    - name: check updating existing RRset and keeping RRs
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -122,7 +122,7 @@
       vars:
         dig: "{{ query('dig_local', 't.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check deleting some of records in exisitng rrset
+    - name: check deleting some of RRs in exisitng RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -147,7 +147,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.srv.rrset.example.', qtype='SRV', flat=0, fail_on_error=false, real_empty=false) | tojson }}"
 
-    - name: check updating existing rrset with same content
+    - name: check updating existing RRset with same RR content
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -168,7 +168,7 @@
       vars:
         dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check deleting nonexistent record from existing rrset
+    - name: check deleting nonexistent RR from existing RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -189,7 +189,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.cname.rrset.example.', qtype='CNAME', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check deleting nonexistent rrset
+    - name: check deleting nonexistent RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -232,7 +232,7 @@
           - result.failed
           - not result.changed
 
-    - name: check missing options in rrset
+    - name: check missing options in RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -248,7 +248,7 @@
           - result.failed
           - not result.changed
 
-    - name: check listing all rrsets of a zone
+    - name: check listing all RRsets of a zone
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: exists
@@ -261,7 +261,7 @@
           - not result.changed
           - (result['rrsets'] | length) == 22
 
-    - name: check listing all rrsets of a given type
+    - name: check listing all RRsets of a given type
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: exists
@@ -276,7 +276,7 @@
           - result.exists
           - (result.rrsets | map(attribute='type') | unique | list) == ["A"]
 
-    - name: check listing all rrsets of a given name
+    - name: check listing all RRsets of a given name
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: exists

--- a/workflow-support/ansible-2.15/test-rrset-record.yml
+++ b/workflow-support/ansible-2.15/test-rrset-record.yml
@@ -259,7 +259,7 @@
           - result['exception'] is not defined
           - not result.failed
           - not result.changed
-          - (result['rrsets'] | length) == 22
+          - (result['rrsets'] | length) == 20
 
     - name: check listing all RRsets of a given type
       kpfleming.powerdns_auth.rrset:

--- a/workflow-support/ansible-2.15/test-rrset-record.yml
+++ b/workflow-support/ansible-2.15/test-rrset-record.yml
@@ -1,0 +1,292 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - rrset-vars.yml
+
+  vars:
+    ansible_python_interpreter: python
+    api_key: foo
+    common_args: &common
+      api_key: foo
+      zone_name: rrset.example.
+
+  pre_tasks:
+    - ansible.builtin.debug:
+        var: ansible_python_interpreter
+
+    - name: Creating template for all rrset types
+      ansible.builtin.template:
+        src: ./template/all-rrset-types.yml.j2
+        dest: ./template/test-rrset-all-types.yml
+        mode: "644"
+
+    - ansible.builtin.set_fact:
+        rrsets: "{{ rrsets_dnssec }}"
+
+    - name: Creating template for all rrset dnssec types
+      ansible.builtin.template:
+        src: ./template/all-rrset-types.yml.j2
+        dest: ./template/test-rrset-all-dnssec-types.yml
+        mode: "644"
+
+    - name: check "Native" zone creation
+      kpfleming.powerdns_auth.zone:
+        api_key: "{{ api_key }}"
+        name: rrset.example.
+        state: present
+        properties:
+          kind: Native
+          nameservers:
+            - ns.example.
+          soa:
+            mname: localhost.
+            rname: hostmaster.localhost.
+      register: result
+
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - result.zone.name == "rrset.example."
+          - result.zone.kind == "Native"
+
+  tasks:
+    - name: check creating each type of supported DNS record
+      ansible.builtin.include_tasks:
+        file: ./template/test-rrset-all-types.yml
+
+    - name: check creating each type of supported DNSSEC record
+      ansible.builtin.include_tasks:
+        file: ./template/test-rrset-all-dnssec-types.yml
+
+    - name: check deleting existing rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.hinfo.rrset.example.
+        type: HINFO
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - dig == "NXDOMAIN"
+      vars:
+        dig: "{{ lookup('dig_local', 't.hinfo.rrset.example.', qtype='HINFO', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check updating existing rrset by replacing all records
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.aaaa.rrset.example.
+        type: AAAA
+        ttl: 7200
+        records:
+          - content: 2001:db8::3
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - dig['address'] == "2001:db8::3"
+          - dig['ttl'] == 7200
+      vars:
+        dig: "{{ lookup('dig_local', 't.aaaa.rrset.example.', qtype='AAAA', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check updating existing rrset and keeping records
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.A.rrset.example.
+        keep: true
+        A:
+          - address: 10.0.0.1
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - (dig | sort(attribute='address') | map(attribute='address') | list) == ['10.0.0.1', '192.168.1.1']
+          - (dig | map(attribute='ttl') | unique | list) == [3600]
+      vars:
+        dig: "{{ query('dig_local', 't.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check deleting some of records in exisitng rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.srv.rrset.example.
+        keep: true
+        SRV:
+          - priority: 5
+            weight: 1
+            port: 443
+            target: web.example.com.
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - dig['target'] == "xmpp.example.com."
+          - dig['port'] == 5222
+          - dig['ttl'] == 3600
+          - dig['owner'] == "t.srv.rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 't.srv.rrset.example.', qtype='SRV', flat=0, fail_on_error=false, real_empty=false) | tojson }}"
+
+    - name: check updating existing rrset with same content
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: rrset.example.
+        keep: true
+        NS:
+          - host: ns1.example.com.
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - dig['target'] == "ns1.example.com."
+          - dig['ttl'] == 3600
+          - dig['owner'] == "rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check deleting nonexistent record from existing rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.cname.rrset.example.
+        keep: true
+        CNAME:
+          - cname: app1.example.com
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - dig['target'] == "app.example.com."
+          - dig['ttl'] == 3600
+          - dig['owner'] == "t.cname.rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 't.cname.rrset.example.', qtype='CNAME', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check deleting nonexistent rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.NX.rrset.example.
+        type: A
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - not result.changed
+
+    - name: check operation on nonexistent zone
+      kpfleming.powerdns_auth.rrset:
+        api_key: foo
+        zone_name: NS.example.
+        state: absent
+        name: t.A.rrset.example.
+        type: A
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - not result.changed
+
+    - name: check missing options
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.A.rrset.example.
+        keep: true
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - not result.changed
+
+    - name: check missing options in rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.NAPTR.rrset.example.
+        keep: true
+        NAPTR:
+          - order: 2
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result.failed
+          - not result.changed
+
+    - name: check listing all rrsets of a zone
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: exists
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - (result['rrsets'] | length) == 22
+
+    - name: check listing all rrsets of a given type
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: exists
+        type: A
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - (result.rrsets | map(attribute='type') | unique | list) == ["A"]
+
+    - name: check listing all rrsets of a given name
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: exists
+        name: rrset.example.
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - (result.rrsets | map(attribute='name') | unique | list) == ["rrset.example."]

--- a/workflow-support/ansible-2.19/lookup_plugins/dig_local.py
+++ b/workflow-support/ansible-2.19/lookup_plugins/dig_local.py
@@ -38,7 +38,7 @@ DOCUMENTATION = '''
             - C(CAA) has been added in community.general 6.3.0.
         type: str
         default: 'A'
-        choices: [A, ALL, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC, MX, NAPTR, NS, NSEC3PARAM, PTR, RP, RRSIG, SOA, SPF, SRV, SSHFP, TLSA, TXT]
+        choices: [A, ALL, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, HTTPS, LOC, MX, NAPTR, NS, NSEC, NSEC3PARAM, PTR, RP, RRSIG, SOA, SPF, SRV, SSHFP, SVCB, TLSA, TXT]
       flat:
         description: If 0 each record is returned as a dictionary, otherwise a string.
         type: int
@@ -205,8 +205,9 @@ try:
     import dns.resolver
     import dns.reversename
     import dns.rdataclass
-    from dns.rdatatype import (A, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, LOC,
-                               MX, NAPTR, NS, NSEC3PARAM, PTR, RP, SOA, SPF, SRV, SSHFP, TLSA, TXT)
+    from dns.rdatatype import (A, AAAA, CAA, CNAME, DNAME, DNSKEY, DS, HINFO, HTTPS, LOC, MX,
+                               NAPTR, NS, NSEC, NSEC3PARAM, PTR, RP, SOA, SPF, SRV, SSHFP,
+                               SVCB, TLSA, TXT)
     HAVE_DNS = True
 except ImportError:
     HAVE_DNS = False
@@ -231,10 +232,12 @@ def make_rdata_dict(rdata):
         DNSKEY: ['flags', 'algorithm', 'protocol', 'key'],
         DS: ['algorithm', 'digest_type', 'key_tag', 'digest'],
         HINFO: ['cpu', 'os'],
+        HTTPS: ['priority', 'target', 'params'],
         LOC: ['latitude', 'longitude', 'altitude', 'size', 'horizontal_precision', 'vertical_precision'],
         MX: ['preference', 'exchange'],
         NAPTR: ['order', 'preference', 'flags', 'service', 'regexp', 'replacement'],
         NS: ['target'],
+        NSEC: ['next', 'windows'],
         NSEC3PARAM: ['algorithm', 'flags', 'iterations', 'salt'],
         PTR: ['target'],
         RP: ['mbox', 'txt'],
@@ -243,6 +246,7 @@ def make_rdata_dict(rdata):
         SPF: ['strings'],
         SRV: ['priority', 'weight', 'port', 'target'],
         SSHFP: ['algorithm', 'fp_type', 'fingerprint'],
+        SVCB: ['priority', 'target', 'params'],
         TLSA: ['usage', 'selector', 'mtype', 'cert'],
         TXT: ['strings'],
     }

--- a/workflow-support/ansible-2.19/rrset-vars.yml
+++ b/workflow-support/ansible-2.19/rrset-vars.yml
@@ -106,13 +106,3 @@ rrsets_dnssec:
         digest_type: 2
         digest: 3f1c2d7a9b0e4a6f8c1d2233445566778899aabbccddeeff0011223344556670
         disabled: false
-  - NSEC:
-      - next_domain: next.example.com.
-        type_bitmap: "A AAAA RRSIG NSEC"
-        disabled: false
-  - NSEC3PARAM:
-      - hash_algorithm: 1
-        flags: 0
-        iterations: 10
-        salt: A1B2C3D4
-        disabled: false

--- a/workflow-support/ansible-2.19/rrset-vars.yml
+++ b/workflow-support/ansible-2.19/rrset-vars.yml
@@ -1,0 +1,118 @@
+rrsets:
+  - A:
+      - address: 192.168.1.1
+        disabled: false
+  - AAAA:
+      - address: 2001:db8:85a3::8a2e:370:7334
+        disabled: false
+      - address: 2001:db8::1
+        disabled: false
+  - CAA:
+      - flags: 0
+        tag: issue
+        value: '"letsencrypt.org"'
+        disabled: false
+  - CNAME:
+      - cname: app.example.com.
+        disabled: false
+  - HINFO:
+      - cpu: '"Intel Xeon"'
+        os: '"Linux"'
+        disabled: false
+  - HTTPS:
+      - priority: 1
+        target: svc.example.com.
+        params: alpn=h2,http/1.1 port=443
+        disabled: false
+  - LOC:
+      - latitude: 37 0 0.000 N
+        longitude: 122 0 0.000 E
+        altitude: 15.00m
+        size: 1.00m
+        horizontal_precision: 10.00m
+        vertical_precision: 2.00m
+        disabled: false
+  - MX:
+      - preference: 10
+        exchange: mail1.example.com.
+        disabled: false
+      - preference: 20
+        exchange: mail2.example.com.
+        disabled: false
+  - NAPTR:
+      - order: 100
+        preference: 50
+        flags: "S"
+        services: "SIP+D2U"
+        regexp: "!^.*$!sip:proxy.example.com!"
+        replacement: .
+        disabled: false
+  - NS:
+      - host: ns1.example.com.
+        disabled: false
+  - PTR:
+      - ptrdname: host-1.example.com.
+        disabled: false
+  - RP:
+      - mbox: hostmaster.example.com.
+        txt: admin-contact.
+        disabled: false
+  - SPF:
+      - strings: "v=spf1 ip4:192.0.2.0/24 include:_spf.example.net ~all"
+        disabled: false
+  - SRV:
+      - priority: 10
+        weight: 5
+        port: 5222
+        target: xmpp.example.com.
+        disabled: false
+      - priority: 5
+        weight: 1
+        port: 443
+        target: web.example.com.
+        disabled: false
+  - SSHFP:
+      - algorithm: 4
+        fp_type: 2
+        fingerprint: 3f1c2d7a9b0e4a6f8c1d2233445566778899aabbccddee112233445566778899
+        disabled: false
+  - SVCB:
+      - priority: 1
+        target: svc.example.com.
+        params: alpn=h2 port=8443 ipv4hint=192.168.2.19
+        disabled: false
+  - TLSA:
+      - usage: 3
+        selector: 1
+        matching_type: 1
+        cert_assoc_data: 9f86d081884c7d659a2feaa0c55ad015
+        disabled: false
+  - TXT:
+      - strings: "v=verify1 abc123"
+        disabled: false
+      - strings: "project=powerdns env=dev"
+        disabled: false
+
+rrsets_dnssec:
+  - DNSKEY:
+      - flags: 257
+        protocol: 3
+        algorithm: 8
+        public_key: AwEAAa1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6A7B8C9D0E1F2G3H4I5J6K7L8M9N0O1P2Q3R4S5T6U7V8W9X0Y1Z2a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8A9B0C1D2E3F4G5H6I7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4a5b6c7d8e9f
+        disabled: false
+  - DS:
+      - key_tag: 2371
+        algorithm: 8
+        digest_type: 2
+        digest: 3f1c2d7a9b0e4a6f8c1d2233445566778899aabbccddeeff0011223344556670
+        disabled: false
+  - NSEC:
+      - next_domain: next.example.com.
+        type_bitmap: "A AAAA RRSIG NSEC"
+        disabled: false
+  - NSEC3PARAM:
+      - hash_algorithm: 1
+        flags: 0
+        iterations: 10
+        salt: A1B2C3D4
+        disabled: false

--- a/workflow-support/ansible-2.19/template/all-rrset-types.yml.j2
+++ b/workflow-support/ansible-2.19/template/all-rrset-types.yml.j2
@@ -1,7 +1,8 @@
 {% for rrset in rrsets %}
 {% set rrset_type = rrset.keys() | first %}
-- name: Creating rrset of type {{ rrset_type }}
+- name: Creating RRset of type {{ rrset_type }}
   kpfleming.powerdns_auth.rrset:
+    {# The following types require the RR to be in the root of the zone #}
     {% if rrset_type in ["DNSKEY", "NS", "NSEC"] %}
         {% set name = "rrset.example." %}
     {% else %}

--- a/workflow-support/ansible-2.19/template/all-rrset-types.yml.j2
+++ b/workflow-support/ansible-2.19/template/all-rrset-types.yml.j2
@@ -3,7 +3,7 @@
 - name: Creating RRset of type {{ rrset_type }}
   kpfleming.powerdns_auth.rrset:
     {# The following types require the RR to be in the root of the zone #}
-    {% if rrset_type in ["DNSKEY", "NS", "NSEC"] %}
+    {% if rrset_type in ["DNSKEY", "NS"] %}
         {% set name = "rrset.example." %}
     {% else %}
         {% set name = "t." ~ rrset_type ~ ".rrset.example." %}

--- a/workflow-support/ansible-2.19/template/all-rrset-types.yml.j2
+++ b/workflow-support/ansible-2.19/template/all-rrset-types.yml.j2
@@ -1,0 +1,32 @@
+{% for rrset in rrsets %}
+{% set rrset_type = rrset.keys() | first %}
+- name: Creating rrset of type {{ rrset_type }}
+  kpfleming.powerdns_auth.rrset:
+    {% if rrset_type in ["DNSKEY", "NS", "NSEC"] %}
+        {% set name = "rrset.example." %}
+    {% else %}
+        {% set name = "t." ~ rrset_type ~ ".rrset.example." %}
+    {% endif %}
+    {% set params = {
+        "zone_name": "rrset.example.",
+        "name": name,
+        "state": "present",
+        "api_key": api_key
+        }
+    %}
+    {{ params | combine(rrset) }}
+  register: result
+
+- ansible.builtin.assert:
+    quiet: true
+    that:
+      - '"exception" not in result'
+      - not result.failed
+      - result.changed
+      - rrset != "NXDOMAIN"
+      - ( rrset | map(attribute='type') | unique | list ) == ["{{ rrset_type }}"]
+      - ( rrset | map(attribute='ttl') | unique | list ) == [3600]
+      - ( rrset | map(attribute='owner') | unique | list ) == ["{{ name }}"]
+  vars:
+    rrset: "{% raw %}{{ query('dig_local', '{% endraw %}{{ name }}{% raw %}', qtype='{% endraw %}{{ rrset_type }}{% raw %}', flat=0, fail_on_error=false, real_empty=false) }}{% endraw %}"
+{% endfor %}

--- a/workflow-support/ansible-2.19/template/test-rrset-all-dnssec-types.yml
+++ b/workflow-support/ansible-2.19/template/test-rrset-all-dnssec-types.yml
@@ -1,0 +1,1 @@
+# File to be replaced during template creation, see test-rrset-record.yml file task "Creating template for all RRset dnssec types"

--- a/workflow-support/ansible-2.19/template/test-rrset-all-types.yml
+++ b/workflow-support/ansible-2.19/template/test-rrset-all-types.yml
@@ -1,0 +1,1 @@
+# File to be replaced during template creation, see test-rrset-record.yml file task "Creating template for all RRset types"

--- a/workflow-support/ansible-2.19/test-cryptokey.yml
+++ b/workflow-support/ansible-2.19/test-cryptokey.yml
@@ -119,8 +119,8 @@
         active: true
       register: result
     - <<: *refresh
-    # For the following test : by default, when creating a Cryptokey and it's the only one present
-    # powerdns will use it as a csk regardless of the keytype passed for its creation
+    # For the following test : by default, when creating a unique CryptoKey in a zone,
+    # powerdns will use it as a csk regardless of the keytype passed for its creation.
     # Once another CryptoKey is present of the opposite type or a csk, powerdns will use
     # the two CryptoKeys as a ksk/zsk pair.
     - ansible.builtin.assert:
@@ -257,7 +257,7 @@
         that:
           - '"exception" in result'
           - result.failed
-          - result.msg == "Wrong options provided for CryptoKey creation"
+          - "result.msg == 'parameters are required together: dnskey, privatekey'"
 
     - name: check missing keytype
       kpfleming.powerdns_auth.cryptokey:

--- a/workflow-support/ansible-2.19/test-cryptokey.yml
+++ b/workflow-support/ansible-2.19/test-cryptokey.yml
@@ -7,7 +7,7 @@
     common_args: &common
       api_key: foo
       zone_name: cryptokeys.example.
-    # For some reason in this test environment changes made to the cryptokeys
+    # For some reason in this test environment changes made to the CryptoKeys
     # are not effective unless some record is updated in the zone hence the following
     # task and its presence throughout the playbook.
     refresh_task: &refresh
@@ -21,7 +21,7 @@
     - ansible.builtin.debug:
         var: ansible_python_interpreter
 
-    - name: Creating Native zone for cryptokeys tests
+    - name: Creating Native zone for CryptoKeys tests
       kpfleming.powerdns_auth.zone:
         name: cryptokeys.example.
         api_key: foo
@@ -50,7 +50,7 @@
           - result.zone.kind == "Native"
 
   tasks:
-    - name: check that there are no keys
+    - name: check that there are no CryptoKeys
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: exists
@@ -62,20 +62,18 @@
           - not result.failed
           - not result.exists
           - not result.changed
-          - result.cryptokey == {}
           - result.cryptokeys == []
           - output == ""
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check generated key creation
+    - name: check generated CryptoKey creation
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          keytype: csk
-          algorithm: ed25519
-          active: true
+        keytype: csk
+        algorithm: ed25519
+        active: true
       register: result
     - <<: *refresh
     - ansible.builtin.assert:
@@ -93,11 +91,11 @@
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=true, real_empty=true)}}"
 
-    - name: check key deletion
+    - name: check CryptoKey deletion
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: absent
-        cryptokey_id: 1
+        id: 1
       register: result
     - <<: *refresh
     - ansible.builtin.assert:
@@ -107,26 +105,24 @@
           - not result.failed
           - result.changed
           - result.cryptokeys == []
-          - result.cryptokey == {}
           - output == ""
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check imported key creation
+    - name: check imported CryptoKey creation
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          keytype: zsk
-          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
-          privatekey: "Private-key-format: v1.2\nAlgorithm: 15 (ED25519)\nPrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n"
-          active: true
+        keytype: zsk
+        dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+        privatekey: "Private-key-format: v1.2\nAlgorithm: 15 (ED25519)\nPrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n"
+        active: true
       register: result
     - <<: *refresh
-    # For the following test : by default, when creating a key and it's the only one present
+    # For the following test : by default, when creating a Cryptokey and it's the only one present
     # powerdns will use it as a csk regardless of the keytype passed for its creation
-    # Once another key is present of the opposite type or a csk, powerdns will use
-    # the two keys as a ksk/zsk pair.
+    # Once another CryptoKey is present of the opposite type or a csk, powerdns will use
+    # the two CryptoKeys as a ksk/zsk pair.
     - ansible.builtin.assert:
         quiet: true
         that:
@@ -142,11 +138,11 @@
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false)}}"
 
-    - name: check getting key by id
+    - name: check getting CryptoKey by id
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: exists
-        cryptokey_id: 1
+        id: 1
       register: result
     - ansible.builtin.assert:
         quiet: true
@@ -155,22 +151,22 @@
           - not result.failed
           - not result.changed
           - result.exists
-          - result.cryptokey["active"] == true
-          - result.cryptokey["keytype"] == "csk"
-          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokey["dnskey"]'
+          - (result.cryptokeys | length) == 1
+          - result.cryptokeys[0]["active"] == true
+          - result.cryptokeys[0]["keytype"] == "csk"
+          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokeys[0]["dnskey"]'
 
-    - name: check listing of all keys
+    - name: check listing of all CryptoKeys
       block:
-        - name: creating key
+        - name: creating CryptoKey
           kpfleming.powerdns_auth.cryptokey:
             <<: *common
             state: present
-            cryptokey:
-              active: false
-              keytype: ksk
-              algorithm: ed25519
+            active: false
+            keytype: ksk
+            algorithm: ed25519
           register: cryptokey
-        - name: getting keys
+        - name: getting CryptoKeys
           kpfleming.powerdns_auth.cryptokey:
             <<: *common
             state: exists
@@ -183,29 +179,27 @@
           - not result.changed
           - result.exists
           - (result.cryptokeys | length) == 2
-          - result.cryptokey == {}
           - cryptokey.changed
 
-    - name: deleting key for following tests
+    - name: deleting CryptoKey for following tests
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: absent
-        cryptokey_id: 1
+        id: 1
     - <<: *refresh
 
-    - name: check activating key
+    - name: check activating CryptoKey
       block:
         - kpfleming.powerdns_auth.cryptokey:
             <<: *common
             state: present
-            cryptokey_id: 2
-            cryptokey:
-              active: true
+            id: 2
+            active: true
           register: cryptokey
         - kpfleming.powerdns_auth.cryptokey:
             <<: *common
             state: "exists"
-            cryptokey_id: 2
+            id: 2
           register: result
     - <<: *refresh
     - ansible.builtin.assert:
@@ -215,16 +209,16 @@
           - '"exception" not in result'
           - not cryptokey.failed
           - not result.failed
-          - result.cryptokey.active == true
+          - result.cryptokeys[0]['active'] == true
           - output["algorithm"] == 15
       vars:
         output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false)}}"
 
-    - name: check getting key by id of nonexistent key
+    - name: check getting CryptoKey by id of nonexistent CryptoKey
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: exists
-        cryptokey_id: 100
+        id: 100
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -249,14 +243,13 @@
           - result.failed
           - result.msg == "No zone found for name nonexistent.example."
 
-    - name: check imported key with wrong parameters
+    - name: check imported CryptoKey with wrong parameters
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          keytype: zsk
-          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
-          active: true
+        keytype: zsk
+        dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+        active: true
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -264,15 +257,14 @@
         that:
           - '"exception" in result'
           - result.failed
-          - result.msg == "Wrong options provided for cryptokey creation"
+          - result.msg == "Wrong options provided for CryptoKey creation"
 
     - name: check missing keytype
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: present
-        cryptokey:
-          algorithm: ed25519
-          active: true
+        algorithm: ed25519
+        active: true
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -280,13 +272,13 @@
         that:
           - '"exception" in result'
           - result.failed
-          - result.msg == "Missing keytype option in cryptokey definition"
+          - result.msg == "Missing keytype option in CryptoKey definition"
 
-    - name: check nonexistent key deletion
+    - name: check nonexistent CryptoKey deletion
       kpfleming.powerdns_auth.cryptokey:
         <<: *common
         state: absent
-        cryptokey_id: 100
+        id: 100
       ignore_errors: true
       register: result
     - ansible.builtin.assert:

--- a/workflow-support/ansible-2.19/test-cryptokey.yml
+++ b/workflow-support/ansible-2.19/test-cryptokey.yml
@@ -1,0 +1,297 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    ansible_python_interpreter: python
+    common_args: &common
+      api_key: foo
+      zone_name: cryptokeys.example.
+    # For some reason in this test environment changes made to the cryptokeys
+    # are not effective unless some record is updated in the zone hence the following
+    # task and its presence throughout the playbook.
+    refresh_task: &refresh
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        name: cryptokeys.example.
+        NS:
+          - host: ns1.example.
+
+  pre_tasks:
+    - ansible.builtin.debug:
+        var: ansible_python_interpreter
+
+    - name: Creating Native zone for cryptokeys tests
+      kpfleming.powerdns_auth.zone:
+        name: cryptokeys.example.
+        api_key: foo
+        state: present
+        properties:
+          kind: Native
+          nameservers:
+            - ns.example.
+          soa:
+            mname: localhost.
+            rname: hostmaster.localhost.
+          rrsets:
+            - name: cryptokeys.example.
+              type: A
+              records:
+                - content: 192.168.1.1
+      register: result
+
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - result.zone.name == "cryptokeys.example."
+          - result.zone.kind == "Native"
+
+  tasks:
+    - name: check that there are no keys
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: exists
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.exists
+          - not result.changed
+          - result.cryptokey == {}
+          - result.cryptokeys == []
+          - output == ""
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check generated key creation
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          keytype: csk
+          algorithm: ed25519
+          active: true
+      register: result
+    - <<: *refresh
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - (result.cryptokeys | length) == 1
+          - result.cryptokeys[0]["algorithm"].lower() == "ed25519"
+          - result.cryptokeys[0]["active"] == true
+          - result.cryptokeys[0]["keytype"] == "csk"
+          - output["algorithm"] == 15
+          - output["type"] == "DNSKEY"
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=true, real_empty=true)}}"
+
+    - name: check key deletion
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: absent
+        cryptokey_id: 1
+      register: result
+    - <<: *refresh
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - result.cryptokeys == []
+          - result.cryptokey == {}
+          - output == ""
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check imported key creation
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          keytype: zsk
+          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+          privatekey: "Private-key-format: v1.2\nAlgorithm: 15 (ED25519)\nPrivateKey: Rnt2dv3mWMmP8bU/8koayZ4R5dWdI86zJmZ0nnjPe6Q=\n"
+          active: true
+      register: result
+    - <<: *refresh
+    # For the following test : by default, when creating a key and it's the only one present
+    # powerdns will use it as a csk regardless of the keytype passed for its creation
+    # Once another key is present of the opposite type or a csk, powerdns will use
+    # the two keys as a ksk/zsk pair.
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - (result.cryptokeys | length) == 1
+          - result.cryptokeys[0]["active"] == true
+          - result.cryptokeys[0]["keytype"] == "csk"
+          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokeys[0]["dnskey"]'
+          - output["key"] == "lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+          - output["algorithm"] == 15
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false)}}"
+
+    - name: check getting key by id
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: exists
+        cryptokey_id: 1
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - result.cryptokey["active"] == true
+          - result.cryptokey["keytype"] == "csk"
+          - '"lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk=" in result.cryptokey["dnskey"]'
+
+    - name: check listing of all keys
+      block:
+        - name: creating key
+          kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: present
+            cryptokey:
+              active: false
+              keytype: ksk
+              algorithm: ed25519
+          register: cryptokey
+        - name: getting keys
+          kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: exists
+          register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - (result.cryptokeys | length) == 2
+          - result.cryptokey == {}
+          - cryptokey.changed
+
+    - name: deleting key for following tests
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: absent
+        cryptokey_id: 1
+    - <<: *refresh
+
+    - name: check activating key
+      block:
+        - kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: present
+            cryptokey_id: 2
+            cryptokey:
+              active: true
+          register: cryptokey
+        - kpfleming.powerdns_auth.cryptokey:
+            <<: *common
+            state: "exists"
+            cryptokey_id: 2
+          register: result
+    - <<: *refresh
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in cryptokey'
+          - '"exception" not in result'
+          - not cryptokey.failed
+          - not result.failed
+          - result.cryptokey.active == true
+          - output["algorithm"] == 15
+      vars:
+        output: "{{ lookup('dig_local', 'cryptokeys.example.', qtype='DNSKEY', flat=0, fail_on_error=false, real_empty=false)}}"
+
+    - name: check getting key by id of nonexistent key
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: exists
+        cryptokey_id: 100
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - not result.exists
+          - result.msg == "API operation getCryptokey returned 'Not Found'"
+
+    - name: check operation on nonexistent zone
+      kpfleming.powerdns_auth.cryptokey:
+        api_key: foo
+        zone_name: nonexistent.example.
+        state: exists
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - result.msg == "No zone found for name nonexistent.example."
+
+    - name: check imported key with wrong parameters
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          keytype: zsk
+          dnskey: "257 3 15 lMu/7quhLeSueMcdlt3T0sxln32yhrhASCKKDB1xJOk="
+          active: true
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - result.msg == "Wrong options provided for cryptokey creation"
+
+    - name: check missing keytype
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: present
+        cryptokey:
+          algorithm: ed25519
+          active: true
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - result.msg == "Missing keytype option in cryptokey definition"
+
+    - name: check nonexistent key deletion
+      kpfleming.powerdns_auth.cryptokey:
+        <<: *common
+        state: absent
+        cryptokey_id: 100
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - result.msg == "Key of id 100 not found for zone cryptokeys.example."

--- a/workflow-support/ansible-2.19/test-rrset-record.yml
+++ b/workflow-support/ansible-2.19/test-rrset-record.yml
@@ -17,7 +17,7 @@
     - ansible.builtin.debug:
         var: ansible_python_interpreter
 
-    - name: Creating template for all rrset types
+    - name: Creating template for all RRset types
       ansible.builtin.template:
         src: ./template/all-rrset-types.yml.j2
         dest: ./template/test-rrset-all-types.yml
@@ -26,7 +26,7 @@
     - ansible.builtin.set_fact:
         rrsets: "{{ rrsets_dnssec }}"
 
-    - name: Creating template for all rrset dnssec types
+    - name: Creating template for all RRset dnssec types
       ansible.builtin.template:
         src: ./template/all-rrset-types.yml.j2
         dest: ./template/test-rrset-all-dnssec-types.yml
@@ -56,15 +56,15 @@
           - result.zone.kind == "Native"
 
   tasks:
-    - name: check creating each type of supported DNS record
+    - name: check creating each type of supported DNS RR
       ansible.builtin.include_tasks:
         file: ./template/test-rrset-all-types.yml
 
-    - name: check creating each type of supported DNSSEC record
+    - name: check creating each type of supported DNSSEC RR
       ansible.builtin.include_tasks:
         file: ./template/test-rrset-all-dnssec-types.yml
 
-    - name: check deleting existing rrset
+    - name: check deleting existing RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -81,7 +81,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.hinfo.rrset.example.', qtype='HINFO', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check updating existing rrset by replacing all records
+    - name: check updating existing RRset by replacing all RRs
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -102,7 +102,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.aaaa.rrset.example.', qtype='AAAA', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check updating existing rrset and keeping records
+    - name: check updating existing RRset and keeping RRs
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -122,7 +122,7 @@
       vars:
         dig: "{{ query('dig_local', 't.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check deleting some of records in exisitng rrset
+    - name: check deleting some RR in exisitng RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -143,7 +143,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.txt.rrset.example.', qtype='TXT', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check updating existing rrset with same content
+    - name: check updating existing RRset with same content
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -164,7 +164,7 @@
       vars:
         dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check deleting nonexistent record from existing rrset
+    - name: check deleting nonexistent RR from existing RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -185,7 +185,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.cname.rrset.example.', qtype='CNAME', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check deleting nonexistent rrset
+    - name: check deleting nonexistent RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: absent
@@ -231,7 +231,7 @@
           - result.failed
           - not result.changed
 
-    - name: check missing options in rrset
+    - name: check missing options in RRset
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -248,7 +248,7 @@
           - result.failed
           - not result.changed
 
-    - name: check listing all rrsets of a zone
+    - name: check listing all RRsets of a zone
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: exists
@@ -261,7 +261,7 @@
           - not result.changed
           - (result['rrsets'] | length) == 22
 
-    - name: check listing all rrsets of a given type
+    - name: check listing all RRsets of a given type
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: exists
@@ -276,7 +276,7 @@
           - result.exists
           - (result.rrsets | map(attribute='type') | unique | list) == ["A"]
 
-    - name: check listing all rrsets of a given name
+    - name: check listing all RRsets of a given name
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: exists

--- a/workflow-support/ansible-2.19/test-rrset-record.yml
+++ b/workflow-support/ansible-2.19/test-rrset-record.yml
@@ -1,0 +1,292 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - rrset-vars.yml
+
+  vars:
+    ansible_python_interpreter: python
+    api_key: foo
+    common_args: &common
+      api_key: foo
+      zone_name: rrset.example.
+
+  pre_tasks:
+    - ansible.builtin.debug:
+        var: ansible_python_interpreter
+
+    - name: Creating template for all rrset types
+      ansible.builtin.template:
+        src: ./template/all-rrset-types.yml.j2
+        dest: ./template/test-rrset-all-types.yml
+        mode: "644"
+
+    - ansible.builtin.set_fact:
+        rrsets: "{{ rrsets_dnssec }}"
+
+    - name: Creating template for all rrset dnssec types
+      ansible.builtin.template:
+        src: ./template/all-rrset-types.yml.j2
+        dest: ./template/test-rrset-all-dnssec-types.yml
+        mode: "644"
+
+    - name: check "Native" zone creation
+      kpfleming.powerdns_auth.zone:
+        api_key: "{{ api_key }}"
+        name: rrset.example.
+        state: present
+        properties:
+          kind: Native
+          nameservers:
+            - ns.example.
+          soa:
+            mname: localhost.
+            rname: hostmaster.localhost.
+      register: result
+
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - result.zone.name == "rrset.example."
+          - result.zone.kind == "Native"
+
+  tasks:
+    - name: check creating each type of supported DNS record
+      ansible.builtin.include_tasks:
+        file: ./template/test-rrset-all-types.yml
+
+    - name: check creating each type of supported DNSSEC record
+      ansible.builtin.include_tasks:
+        file: ./template/test-rrset-all-dnssec-types.yml
+
+    - name: check deleting existing rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.hinfo.rrset.example.
+        type: HINFO
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - dig == "NXDOMAIN"
+      vars:
+        dig: "{{ lookup('dig_local', 't.hinfo.rrset.example.', qtype='HINFO', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check updating existing rrset by replacing all records
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.aaaa.rrset.example.
+        type: AAAA
+        ttl: 7200
+        records:
+          - content: 2001:db8::3
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - dig['address'] == "2001:db8::3"
+          - dig['ttl'] == 7200
+      vars:
+        dig: "{{ lookup('dig_local', 't.aaaa.rrset.example.', qtype='AAAA', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check updating existing rrset and keeping records
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.A.rrset.example.
+        keep: true
+        A:
+          - address: 10.0.0.1
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - (dig | sort(attribute='address') | map(attribute='address') | list) == ['10.0.0.1', '192.168.1.1']
+          - (dig | map(attribute='ttl') | unique | list) == [3600]
+      vars:
+        dig: "{{ query('dig_local', 't.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check deleting some of records in exisitng rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.TXT.rrset.example.
+        keep: true
+        TXT:
+          - strings: "project=powerdns env=dev"
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - (dig['strings'][0] | string) == "b'v=verify1 abc123'"
+          - dig['ttl'] == 3600
+          - dig['owner'] == "t.txt.rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 't.txt.rrset.example.', qtype='TXT', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check updating existing rrset with same content
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: rrset.example.
+        keep: true
+        NS:
+          - host: ns1.example.com.
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - dig['target'] == "ns1.example.com."
+          - dig['ttl'] == 3600
+          - dig['owner'] == "rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check deleting nonexistent record from existing rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.cname.rrset.example.
+        keep: true
+        CNAME:
+          - cname: app1.example.com
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - dig['target'] == "app.example.com."
+          - dig['ttl'] == 3600
+          - dig['owner'] == "t.cname.rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 't.cname.rrset.example.', qtype='CNAME', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check deleting nonexistent rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: absent
+        name: t.NX.rrset.example.
+        type: A
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - not result.changed
+
+    - name: check operation on nonexistent zone
+      kpfleming.powerdns_auth.rrset:
+        api_key: foo
+        zone_name: NS.example.
+        state: absent
+        name: t.A.rrset.example.
+        type: A
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - not result.changed
+
+    - name: check missing options
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.A.rrset.example.
+        keep: true
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - not result.changed
+
+    - name: check missing options in rrset
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: t.NAPTR.rrset.example.
+        keep: true
+        NAPTR:
+          - order: 2
+      ignore_errors: true
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" in result'
+          - result.failed
+          - not result.changed
+
+    - name: check listing all rrsets of a zone
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: exists
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - (result['rrsets'] | length) == 22
+
+    - name: check listing all rrsets of a given type
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: exists
+        type: A
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - (result.rrsets | map(attribute='type') | unique | list) == ["A"]
+
+    - name: check listing all rrsets of a given name
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: exists
+        name: rrset.example.
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - result.exists
+          - (result.rrsets | map(attribute='name') | unique | list) == ["rrset.example."]

--- a/workflow-support/ansible-2.19/test-rrset-record.yml
+++ b/workflow-support/ansible-2.19/test-rrset-record.yml
@@ -259,7 +259,7 @@
           - '"exception" not in result'
           - not result.failed
           - not result.changed
-          - (result['rrsets'] | length) == 22
+          - (result['rrsets'] | length) == 20
 
     - name: check listing all RRsets of a given type
       kpfleming.powerdns_auth.rrset:

--- a/workflow-support/run_test_playbooks.sh
+++ b/workflow-support/run_test_playbooks.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+set -e # in order to fail on any playbook
+
 ansible-playbook -i localhost, workflow-support/ansible-"${1}"/test-tsigkey.yml
 ansible-playbook -i localhost, workflow-support/ansible-"${1}"/test-zone.yml
 ansible-playbook -i localhost, workflow-support/ansible-"${1}"/test-zone-issue-136.yml
 ansible-playbook -i localhost, workflow-support/ansible-"${1}"/test-zone-rrset.yml
+ansible-playbook -i localhost, workflow-support/ansible-"${1}"/test-rrset-record.yml
+ansible-playbook -i localhost, workflow-support/ansible-"${1}"/test-cryptokey.yml


### PR DESCRIPTION
# Description

Adding two new modules:
- powerdns_auth.rrset: manages rrsets and records within them
- powerdns_auth.cryptokey: manages cryptokeys

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Small correction to existing feature (namely api_wrapper.py)

# How has this been tested?

This has been tested with the included github actions manifests.
The current commit hasn't been tested since a change to ci.yml is necessary to make the actions work for forked repos. However this commit differs only on CI configuration from the previous one.
Actions were run on the branch "record-types" and the results are visible [here](https://github.com/mohamed-chamrouk/ansible-powerdns-auth/actions)