### PR TITLE
Improve 'changed' reporting of rrsets module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ for emergencies).
 
 ## [Unreleased]
 
+### Changed
+
+- Improved rrsets and zone modules to eliminate unnecessary 'changed' reporting.
+
 ## [25.2.0] - 2025-10-19
 
 ### Added

--- a/src/plugins/modules/tsigkey.py
+++ b/src/plugins/modules/tsigkey.py
@@ -44,7 +44,7 @@ options:
     default: 'present'
   name:
     description:
-      - Name of the key to be managed.
+      - Name of the key to be managed. The name should end with '.'.
     type: str
     required: true
   algorithm:

--- a/src/plugins/modules/zone.py
+++ b/src/plugins/modules/zone.py
@@ -200,13 +200,15 @@ options:
         elements: str
       master_tsig_key_ids:
         description:
-          - The id of the TSIG keys used for master operation in this zone.
+          - The names of the TSIG keys used for master operation in this zone.
+            The names should end with '.'.
             Only used when O(properties.kind=Master) or O(properties.kind=Producer).
         type: list
         elements: str
       slave_tsig_key_ids:
         description:
-          - The id of the TSIG keys used for slave operation in this zone.
+          - The names of the TSIG keys used for slave operation in this zone.
+            The names should end with '.'.
             Only used when O(properties.kind=Slave) or O(properties.kind=Consumer).
         type: list
         elements: str
@@ -244,7 +246,7 @@ options:
       axfr_master_tsig:
         description:
           - List of TSIG keys used to validate NOTIFY requests from zone masters and to
-            sign AXFR/IXFR requests to zone masters.
+            sign AXFR/IXFR requests to zone masters. The names should end with '.'.
           - "Note: the first key in the list will be used for signing."
         type: list
         elements: str
@@ -311,13 +313,14 @@ options:
       tsig_allow_axfr:
         description:
           - List of TSIG keys used to sign NOTIFY requests and to validate
-            AXFR/IXFR requests.
+            AXFR/IXFR requests. The names should end with '.'.
           - "Note: the first key in the list will be used for signing."
         type: list
         elements: str
       tsig_allow_dnsupdate:
         description:
           - List of TSIG keys for which DNSUPDATE requests will be accepted.
+            The names should end with '.'.
         type: list
         elements: str
 
@@ -438,12 +441,16 @@ zone:
       type: list
       elements: str
     master_tsig_key_ids:
-      description: The id of the TSIG keys used for master operation in this zone.
+      description:
+        - The names of the TSIG keys used for master operation in this zone.
+          The names should end with '.'.
       returned: when present
       type: list
       elements: str
     slave_tsig_key_ids:
-      description: The id of the TSIG keys used for slave operation in this zone.
+      description:
+        - The names of the TSIG keys used for slave operation in this zone.
+          The names should end with '.'.
       returned: when present
       type: list
       elements: str
@@ -476,7 +483,7 @@ zone:
         axfr_master_tsig:
           description:
             - List of TSIG keys used to validate NOTIFY requests from zone masters and to
-              sign AXFR/IXFR requests to zone masters.
+              sign AXFR/IXFR requests to zone masters. The names should end with '.'.
           type: list
           elements: str
         axfr_source:
@@ -551,12 +558,13 @@ zone:
         tsig_allow_axfr:
           description:
             - List of TSIG keys used to sign NOTIFY requests and to validate
-              AXFR/IXFR requests.
+              AXFR/IXFR requests. The names should end with '.'.
           type: list
           elements: str
         tsig_allow_dnsupdate:
           description:
             - List of TSIG keys for which DNSUPDATE requests will be accepted.
+              The names should end with '.'.
           type: list
           elements: str
 """
@@ -746,7 +754,7 @@ class MetadataListValue(Metadata):
             )
 
     def update(self, oldval, newval, api_zone_metadata_client):
-        if newval == oldval:
+        if sorted(newval) == sorted(oldval):
             return False
 
         if len(newval) != 0:

--- a/workflow-support/ansible-2.15/test-cryptokey.yml
+++ b/workflow-support/ansible-2.15/test-cryptokey.yml
@@ -1,3 +1,4 @@
+---
 - hosts: localhost
   connection: local
   gather_facts: false
@@ -7,13 +8,16 @@
     common_args: &common
       api_key: foo
       zone_name: cryptokeys.example.
-    # For some reason in this test environment changes made to the CryptoKeys
-    # are not effective unless some record is updated in the zone hence the following
-    # task and its presence throughout the playbook.
+    # For some reason in this test environment changes made to the
+    # CryptoKeys are not effective unless some record is updated in
+    # the zone hence the following task and its presence throughout
+    # the playbook. A random-number generator is used for the TTL to
+    # ensure that the RRset will be changed.
     refresh_task: &refresh
       kpfleming.powerdns_auth.rrset:
         <<: *common
         name: cryptokeys.example.
+        ttl: "{{ 86400 | random(start=60) }}"
         NS:
           - host: ns1.example.
 

--- a/workflow-support/ansible-2.15/test-rrset-record.yml
+++ b/workflow-support/ansible-2.15/test-rrset-record.yml
@@ -147,7 +147,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.srv.rrset.example.', qtype='SRV', flat=0, fail_on_error=false, real_empty=false) | tojson }}"
 
-    - name: check updating existing RRset with same RR content
+    - name: check updating existing RRset with same content (keep=true)
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -167,6 +167,70 @@
           - dig['owner'] == "rrset.example."
       vars:
         dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check updating existing RRset with same content (keep=false)
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: rrset.example.
+        NS:
+          - host: ns1.example.com.
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - dig['target'] == "ns1.example.com."
+          - dig['ttl'] == 3600
+          - dig['owner'] == "rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check creating RRset with multiple records
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: multi.A.rrset.example.
+        keep: true
+        A:
+          - address: 10.0.0.1
+          - address: 172.0.0.1
+          - address: 127.0.0.53
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - result.changed
+          - (dig | sort(attribute='address') | map(attribute='address') | list) == ['10.0.0.1', '127.0.0.53', '172.0.0.1']
+          - (dig | map(attribute='ttl') | unique | list) == [3600]
+      vars:
+        dig: "{{ query('dig_local', 'multi.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check confirming RRset with multiple records in a different order
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: multi.A.rrset.example.
+        keep: true
+        A:
+          - address: 127.0.0.53
+          - address: 10.0.0.1
+          - address: 172.0.0.1
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - result['exception'] is not defined
+          - not result.failed
+          - not result.changed
+          - (dig | sort(attribute='address') | map(attribute='address') | list) == ['10.0.0.1', '127.0.0.53', '172.0.0.1']
+          - (dig | map(attribute='ttl') | unique | list) == [3600]
+      vars:
+        dig: "{{ query('dig_local', 'multi.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
 
     - name: check deleting nonexistent RR from existing RRset
       kpfleming.powerdns_auth.rrset:
@@ -259,7 +323,7 @@
           - result['exception'] is not defined
           - not result.failed
           - not result.changed
-          - (result['rrsets'] | length) == 20
+          - (result['rrsets'] | length) == 21
 
     - name: check listing all RRsets of a given type
       kpfleming.powerdns_auth.rrset:

--- a/workflow-support/ansible-2.19/rrset-vars.yml
+++ b/workflow-support/ansible-2.19/rrset-vars.yml
@@ -1,3 +1,4 @@
+---
 rrsets:
   - A:
       - address: 192.168.1.1
@@ -98,7 +99,8 @@ rrsets_dnssec:
       - flags: 257
         protocol: 3
         algorithm: 8
-        public_key: AwEAAa1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6A7B8C9D0E1F2G3H4I5J6K7L8M9N0O1P2Q3R4S5T6U7V8W9X0Y1Z2a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8A9B0C1D2E3F4G5H6I7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4a5b6c7d8e9f
+        public_key:
+          AwEAAa1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6A7B8C9D0E1F2G3H4I5J6K7L8M9N0O1P2Q3R4S5T6U7V8W9X0Y1Z2a3b4c5d6e7f8g9h0i1j2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8A9B0C1D2E3F4G5H6I7J8K9L0M1N2O3P4Q5R6S7T8U9V0W1X2Y3Z4a5b6c7d8e9f
         disabled: false
   - DS:
       - key_tag: 2371

--- a/workflow-support/ansible-2.19/test-cryptokey.yml
+++ b/workflow-support/ansible-2.19/test-cryptokey.yml
@@ -1,3 +1,4 @@
+---
 - hosts: localhost
   connection: local
   gather_facts: false
@@ -7,13 +8,16 @@
     common_args: &common
       api_key: foo
       zone_name: cryptokeys.example.
-    # For some reason in this test environment changes made to the CryptoKeys
-    # are not effective unless some record is updated in the zone hence the following
-    # task and its presence throughout the playbook.
+    # For some reason in this test environment changes made to the
+    # CryptoKeys are not effective unless some record is updated in
+    # the zone hence the following task and its presence throughout
+    # the playbook. A random-number generator is used for the TTL to
+    # ensure that the RRset will be changed.
     refresh_task: &refresh
       kpfleming.powerdns_auth.rrset:
         <<: *common
         name: cryptokeys.example.
+        ttl: "{{ 86400 | random(start=60) }}"
         NS:
           - host: ns1.example.
 

--- a/workflow-support/ansible-2.19/test-rrset-record.yml
+++ b/workflow-support/ansible-2.19/test-rrset-record.yml
@@ -143,7 +143,7 @@
       vars:
         dig: "{{ lookup('dig_local', 't.txt.rrset.example.', qtype='TXT', flat=0, fail_on_error=false, real_empty=false) }}"
 
-    - name: check updating existing RRset with same content
+    - name: check updating existing RRset with same content (keep=true)
       kpfleming.powerdns_auth.rrset:
         <<: *common
         state: present
@@ -163,6 +163,70 @@
           - dig['owner'] == "rrset.example."
       vars:
         dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check updating existing RRset with same content (keep=false)
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: rrset.example.
+        NS:
+          - host: ns1.example.com.
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - dig['target'] == "ns1.example.com."
+          - dig['ttl'] == 3600
+          - dig['owner'] == "rrset.example."
+      vars:
+        dig: "{{ lookup('dig_local', 'rrset.example.', qtype='NS', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check creating RRset with multiple records
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: multi.A.rrset.example.
+        keep: true
+        A:
+          - address: 10.0.0.1
+          - address: 172.0.0.1
+          - address: 127.0.0.53
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - result.changed
+          - (dig | sort(attribute='address') | map(attribute='address') | list) == ['10.0.0.1', '127.0.0.53', '172.0.0.1']
+          - (dig | map(attribute='ttl') | unique | list) == [3600]
+      vars:
+        dig: "{{ query('dig_local', 'multi.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
+
+    - name: check confirming RRset with multiple records in a different order
+      kpfleming.powerdns_auth.rrset:
+        <<: *common
+        state: present
+        name: multi.A.rrset.example.
+        keep: true
+        A:
+          - address: 127.0.0.53
+          - address: 10.0.0.1
+          - address: 172.0.0.1
+      register: result
+    - ansible.builtin.assert:
+        quiet: true
+        that:
+          - '"exception" not in result'
+          - not result.failed
+          - not result.changed
+          - (dig | sort(attribute='address') | map(attribute='address') | list) == ['10.0.0.1', '127.0.0.53', '172.0.0.1']
+          - (dig | map(attribute='ttl') | unique | list) == [3600]
+      vars:
+        dig: "{{ query('dig_local', 'multi.a.rrset.example.', qtype='A', flat=0, fail_on_error=false, real_empty=false) }}"
 
     - name: check deleting nonexistent RR from existing RRset
       kpfleming.powerdns_auth.rrset:
@@ -259,7 +323,7 @@
           - '"exception" not in result'
           - not result.failed
           - not result.changed
-          - (result['rrsets'] | length) == 20
+          - (result['rrsets'] | length) == 21
 
     - name: check listing all RRsets of a given type
       kpfleming.powerdns_auth.rrset:


### PR DESCRIPTION
When the 'rrsets' module does not actually need to make any changes, it should not issue the zone-modification API call or report a 'changed' status. The existing code partially attempted to implement this optimization, but it did not work unless 'keep' was set to True, and the comparison between the provided and existing lists of records was ineffective because extraneous attributes were present in the 'existing' record list. Finally, the comparison of lists of records did not ensure that the lists were sorted before comparison.