### PR TITLE
Pin setuptools to version 81 or lower

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ can be installed, like this:
 pip install -r requirements.txt
 ```
 
+In addition, these versions of the packages rely on deprecated
+functionality from the `setuptools` package, which was removed in
+version 82. As a result the full requirements list includes pinning
+setuptools to version 81 or lower.
+
 This command can be executed in the environment on the Ansible
 controller if the roles will be used only on 'localhost'; if they will
 be used on Ansible-managed nodes, then the packages from the
@@ -41,6 +46,7 @@ requirements file will need to be installed there:
     name:
       - bravado
       - jsonschema<4
+	  - setuptools<82
       - swagger-spec-validator==2.6.0
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bravado
 jsonschema<4
+setuptools<82
 swagger-spec-validator==2.6.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,4 @@
 bravado
 jsonschema<4
+setuptools<82
 swagger-spec-validator==2.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ deps=
     bravado
     dnspython
     jsonschema<4
+    setuptools<82
     swagger-spec-validator==2.6.0
 setenv=
     {[galaxy-setup]setenv}
@@ -90,6 +91,7 @@ deps=
     bravado
     dnspython
     jsonschema<4
+    setuptools<82
     swagger-spec-validator==2.6.0
 setenv=
     {[galaxy-setup]setenv}


### PR DESCRIPTION
Version 82 of the setuptools package removed 'pkg_resources' which had been deprecated for a long time. Unfortunately the versions of Bravado and its dependencies which are required for this collection rely on 'pkg_resources' and thus cannot be used in a Python environment with a current version of setuptools.