### PR TITLE
Split tox environments by pdns version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
         show-progress: false
     - name: start pdns_server
       run: workflow-support/start_server.sh ${{ inputs.pdns }}
-    - uses: kpfleming/composite-actions/ci-tox@v3
-      with:
-        python: ${{ inputs.python }}
+    - name: run CI tests
+      run: tox run -e${{ inputs.python }}-pdns${{ inputs.pdns }}-ci-action
+      shell: bash
       env:
         pdns_version: ${{ inputs.pdns }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ for emergencies).
 
 - Improved rrsets and zone modules to eliminate unnecessary 'changed' reporting.
 
+- Removed testing against the 'master' branch of PowerDNS Auth, as the API
+  schema in that branch has been converted to OpenAPI 3.1 format and
+  the Bravado API client package used in this collection does not
+  support OpenAPI. This also means that this collection will not
+  support PowerDNS Auth 5.1.0 or later versions until a new API client
+  package has been chosen and incorporated into the collection.
+
 ## [25.2.0] - 2025-10-19
 
 ### Added

--- a/tox.ini
+++ b/tox.ini
@@ -84,27 +84,6 @@ commands_pre=
 commands=
     bash -c 'workflow-support/run_test_playbooks.sh 2.15'
 
-[testenv:py310-pdnsmaster-ci-action]
-deps=
-    {[galaxy-setup]deps}
-    ansible-core
-    bravado
-    dnspython
-    jsonschema
-    setuptools
-    swagger-spec-validator
-setenv=
-    {[galaxy-setup]setenv}
-passenv=
-    pdns_version
-allowlist_externals=
-    bash
-commands_pre=
-    {[galaxy-setup]commands_pre}
-    {[galaxy-setup]commands}
-commands=
-    bash -c 'workflow-support/run_test_playbooks.sh 2.15'
-
 [testenv:py{311,312,313,314}-pdns{4.8,4.9,5.0}-ci-action]
 deps=
     {[galaxy-setup]deps}
@@ -114,27 +93,6 @@ deps=
     jsonschema<4
     setuptools<82
     swagger-spec-validator==2.6.0
-setenv=
-    {[galaxy-setup]setenv}
-passenv=
-    pdns_version
-allowlist_externals=
-    bash
-commands_pre=
-    {[galaxy-setup]commands_pre}
-    {[galaxy-setup]commands}
-commands=
-    bash -c 'workflow-support/run_test_playbooks.sh 2.19'
-
-[testenv:py{311,312,313,314}-pdnsmaster-ci-action]
-deps=
-    {[galaxy-setup]deps}
-    ansible-core
-    bravado
-    dnspython
-    jsonschema
-    setuptools
-    swagger-spec-validator
 setenv=
     {[galaxy-setup]setenv}
 passenv=

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands=
     ruff check --output-format=full --fix --show-fixes src
     ansible-lint --fix all --strict --profile production -v
 
-[testenv:py310-ci-action]
+[testenv:py310-pdns{4.8,4.9,5.0}-ci-action]
 deps=
     {[galaxy-setup]deps}
     ansible-core
@@ -84,7 +84,28 @@ commands_pre=
 commands=
     bash -c 'workflow-support/run_test_playbooks.sh 2.15'
 
-[testenv:py{311,312,313,314}-ci-action]
+[testenv:py310-pdnsmaster-ci-action]
+deps=
+    {[galaxy-setup]deps}
+    ansible-core
+    bravado
+    dnspython
+    jsonschema
+    setuptools
+    swagger-spec-validator
+setenv=
+    {[galaxy-setup]setenv}
+passenv=
+    pdns_version
+allowlist_externals=
+    bash
+commands_pre=
+    {[galaxy-setup]commands_pre}
+    {[galaxy-setup]commands}
+commands=
+    bash -c 'workflow-support/run_test_playbooks.sh 2.15'
+
+[testenv:py{311,312,313,314}-pdns{4.8,4.9,5.0}-ci-action]
 deps=
     {[galaxy-setup]deps}
     ansible-core
@@ -93,6 +114,27 @@ deps=
     jsonschema<4
     setuptools<82
     swagger-spec-validator==2.6.0
+setenv=
+    {[galaxy-setup]setenv}
+passenv=
+    pdns_version
+allowlist_externals=
+    bash
+commands_pre=
+    {[galaxy-setup]commands_pre}
+    {[galaxy-setup]commands}
+commands=
+    bash -c 'workflow-support/run_test_playbooks.sh 2.19'
+
+[testenv:py{311,312,313,314}-pdnsmaster-ci-action]
+deps=
+    {[galaxy-setup]deps}
+    ansible-core
+    bravado
+    dnspython
+    jsonschema
+    setuptools
+    swagger-spec-validator
 setenv=
     {[galaxy-setup]setenv}
 passenv=

--- a/workflow-support/make_ci_image.sh
+++ b/workflow-support/make_ci_image.sh
@@ -15,7 +15,8 @@ lint_deps=(shellcheck)
 publish_deps=(yq)
 
 toxenvs=(lint-action ci-action publish-action)
-cimatrix=(py3{10,11,12,13,14})
+py_versions=(py3{10,11,12,13,14})
+pdns_versions=(pdns{4.8,4.9,5.0,master})
 
 c=$(buildah from "${base_image}")
 
@@ -58,8 +59,10 @@ buildah config --env TOX_USER_CONFIG_FILE=/tox/config.ini "${c}"
 for env in "${toxenvs[@]}"; do
     case "${env}" in
 	ci-action)
-	    for py in "${cimatrix[@]}"; do
-		build_cmd_with_source tox exec -e "${py}-${env}" -- uv pip list
+	    for py in "${py_versions[@]}"; do
+		for pdns in "${pdns_versions[@]}"; do
+		    build_cmd_with_source tox exec -e "${py}-${pdns}-${env}" -- uv pip list
+		done
 	    done
 	;;
 	*)

--- a/workflow-support/make_ci_image.sh
+++ b/workflow-support/make_ci_image.sh
@@ -16,7 +16,7 @@ publish_deps=(yq)
 
 toxenvs=(lint-action ci-action publish-action)
 py_versions=(py3{10,11,12,13,14})
-pdns_versions=(pdns{4.8,4.9,5.0,master})
+pdns_versions=(pdns{4.8,4.9,5.0})
 
 c=$(buildah from "${base_image}")
 

--- a/workflow-support/make_ci_image.sh
+++ b/workflow-support/make_ci_image.sh
@@ -35,12 +35,12 @@ build_cmd apt install --yes --quiet=2 "${proj_build_deps[@]}" "${lint_deps[@]}" 
 for pdns_ver in "${@}"; do
     case "${pdns_ver}" in
 	master)
-	    pdns_url=https://github.com/PowerDNS/pdns/archive/refs/heads/master.tar.gz
-	    pdns_dir=pdns-master
+	    pdns_url="https://github.com/PowerDNS/pdns/archive/refs/heads/master.tar.gz"
+	    pdns_dir="pdns-master"
 	    ;;
 	*)
-	    pdns_url=https://github.com/PowerDNS/pdns/archive/refs/heads/rel/auth-"${pdns_ver}".x.tar.gz
-	    pdns_dir=pdns-rel-auth-"${pdns_ver}".x
+	    pdns_url="https://github.com/PowerDNS/pdns/archive/refs/heads/rel/auth-${pdns_ver}.x.tar.gz"
+	    pdns_dir="pdns-rel-auth-${pdns_ver}.x"
 	    ;;
     esac
 

--- a/workflow-support/versions.json
+++ b/workflow-support/versions.json
@@ -1,1 +1,1 @@
-versions={"pdns":["4.8", "4.9", "5.0", "master"], "python": ["py310", "py311", "py312", "py313", "py314"]}
+versions={"pdns":["4.8", "4.9", "5.0"], "python": ["py310", "py311", "py312", "py313", "py314"]}


### PR DESCRIPTION
PowerDNS Auth 'master' has a significantly upgraded OpenAPI schema, and requires a different combination of Bravado and its dependencies. This commit reconfigures tox.ini and the test.yml workflow to provide separate test environments for specific PowerDNS versions.